### PR TITLE
ci(release): review-pass fixes from PR #37

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,22 +306,23 @@ jobs:
           pub_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           base="https://github.com/${REPO}/releases/download/${TAG}"
 
-          # Helper: emit a "platform -> { url, signature }" object for
-          # each installer file + matching .sig file present.
-          entries=""
-          # Per-installer entries (linux-{arch}-{installer}, darwin-aarch64)
-          # are what the plugin's get_urls() looks up first based on the
-          # binary's __TAURI_BUNDLE_TYPE constant. The bare linux-{arch}
-          # entries are kept as a fallback for binaries with an unknown
-          # bundle type (e.g., builds outside the Tauri bundler).
+          # Build the platforms object via jq with --arg for every value
+          # so signatures and URLs go through proper JSON escaping (no
+          # shell-level sed for quotes — defense in depth even though
+          # minisign output is base64). Per-installer entries (e.g.
+          # linux-x86_64-deb) are what the updater plugin's get_urls()
+          # looks up first based on the binary's __TAURI_BUNDLE_TYPE
+          # constant. The bare linux-{arch} fallbacks come first within
+          # each arch block, matching the spec's sample manifest order.
+          platforms='{}'
           for pair in \
             "windows-x86_64:*-setup.exe" \
+            "linux-x86_64:*_amd64.AppImage" \
             "linux-x86_64-appimage:*_amd64.AppImage" \
             "linux-x86_64-deb:*_amd64.deb" \
-            "linux-x86_64:*_amd64.AppImage" \
+            "linux-aarch64:*_aarch64.AppImage" \
             "linux-aarch64-appimage:*_aarch64.AppImage" \
             "linux-aarch64-deb:*_arm64.deb" \
-            "linux-aarch64:*_aarch64.AppImage" \
             "darwin-aarch64:*.app.tar.gz" \
           ; do
             plat="${pair%%:*}"
@@ -334,13 +335,13 @@ jobs:
               echo "skip $plat — no signature for $installer (signing secret missing?)"
               continue
             fi
-            sig=$(cat "$sig_file")
-            if [ -n "$entries" ]; then entries="$entries,"; fi
-            entries+=$(printf '"%s":{"url":"%s/%s","signature":"%s"}' \
-              "$plat" "$base" "$installer" "$(echo "$sig" | tr -d '\n' | sed 's/"/\\"/g')")
+            sig=$(tr -d '\n' < "$sig_file")
+            url="${base}/${installer}"
+            platforms=$(jq --arg p "$plat" --arg u "$url" --arg s "$sig" \
+              '. + {($p): {url: $u, signature: $s}}' <<< "$platforms")
           done
 
-          if [ -z "$entries" ]; then
+          if [ "$platforms" = '{}' ]; then
             echo "No signed installers found — skipping latest.json."
             exit 0
           fi
@@ -349,7 +350,7 @@ jobs:
             --arg v "$version" \
             --arg n "$notes" \
             --arg d "$pub_date" \
-            --argjson p "{$entries}" \
+            --argjson p "$platforms" \
             '{version:$v, notes:$n, pub_date:$d, platforms:$p}' \
             > latest.json
           echo "--- latest.json ---"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
             librsvg2-dev \
             build-essential \
             curl wget file xz-utils patchelf \
-            fuse libfuse2 desktop-file-utils
+            fuse libfuse2 desktop-file-utils \
+            minisign
 
       - name: Build UI (Next.js static export)
         run: |
@@ -175,17 +176,17 @@ jobs:
             echo "::warning::TAURI_SIGNING_PRIVATE_KEY not set — skipping .deb signing"
             exit 0
           fi
-          sudo apt-get install -y minisign
-          BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
-          DEB_DIR="$BUNDLE_DIR/deb"
+          DEB_DIR="target/${{ matrix.target }}/release/bundle/deb"
           if [ ! -d "$DEB_DIR" ]; then
             echo "no deb bundle dir at $DEB_DIR — nothing to sign"
             exit 0
           fi
-          # Stage the secret to a real file so minisign can mmap it.
-          # Using a process substitution doesn't survive minisign's
-          # reopen-on-EOF behavior on the secret-key path.
+          # Stage the secret to a real file so minisign can mmap it
+          # (process substitution doesn't survive minisign's reopen-on-EOF
+          # behavior on the secret-key path). trap EXIT guarantees the
+          # tempfile is removed even if the job is cancelled mid-loop.
           KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
           chmod 600 "$KEY_FILE"
           printf '%s' "${TAURI_SIGNING_PRIVATE_KEY}" > "$KEY_FILE"
           for deb in "$DEB_DIR"/*.deb; do
@@ -203,7 +204,6 @@ jobs:
                   -x "${deb}.sig"
             echo "signed: ${deb}.sig"
           done
-          rm -f "$KEY_FILE"
 
       - name: Package portable tar.xz + collect installers
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,16 @@ on:
       - 'v*'
   workflow_dispatch:
 
-permissions:
-  contents: write
+# No workflow-level permissions block. Each job declares the minimum
+# scope it needs (build = read; release / prune = write). Limits the
+# blast radius if the build job's secret-handling steps ever go sideways.
 
 jobs:
   build:
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -265,6 +268,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
@@ -426,6 +431,8 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     env:
       # Bump this to keep more (or fewer) releases. Counts every release
       # GitHub knows about, drafts and prereleases included.


### PR DESCRIPTION
Follow-up to #37 (already merged) — applies the six Important findings the four-reviewer pass surfaced. All workflow-only.

## Fixes

| ID | Severity | Finding | Commit |
|---|---|---|---|
| I1 | Important | \`apt-get install minisign\` was a separate call after the dir-check; folded into existing Linux deps step | fa21f83 |
| I2 | Important | \`\$KEY_FILE\` had no \`trap EXIT\`; secret could survive cancellation between write and rm | fa21f83 |
| I3 | Important | Manifest entries were built via shell printf + sed quote-escape; now built via \`jq --arg\` | 42ddf7b |
| I4 | Important | \`permissions: contents: write\` was workflow-level; scoped per-job (build:read, release:write, prune:write) | 56e66f8 |
| I5 | Important | \`for pair in\` order put fallback in middle of arch block; reordered to fallback-first to match spec §6 | 42ddf7b |
| I6 | Important | \`\$BUNDLE_DIR\` intermediate variable was unused beyond \`\$DEB_DIR\`; inlined | fa21f83 |

## State note

**v1.1.3 has not been tagged yet** (no release-workflow run on \`main\` since the #37 merge). Two ways to ship this:

- **Option A — fold into v1.1.3:** hold off tagging until this PR merges, then tag \`v1.1.3\` from main. The Cargo.toml version stays at 1.1.3 in this PR; nothing changes in the release notes.
- **Option B — ship v1.1.3 now, ship these as v1.1.4:** tag \`v1.1.3\` from main as it stands today, then I'll bump this branch to 1.1.4 + add a v1.1.4 release notes file before merging this PR.

Recommend **A** — the changes here are review-driven cleanups of code that hasn't shipped yet, so a single combined release is cleaner.

## Skipped findings (Minor)

The four reviewers also surfaced 6 Minor findings that you elected to skip. Recap:
- M1: \`ls \$glob | head -n1\` unguarded (sub-ms cost, not an actual issue today)
- M2: \`minisign\` not version-pinned (defense-in-depth supply-chain note)
- M3: verify step shells out to \`jq\` twice (pure stylistic)
- M4: 8-entry \`for pair\` list at readability ceiling (future consideration)
- M5: \`if-no-files-found: warn\` on installer-artifacts (informational; verify step is the real gate)
- M6: macOS .app without Apple notarization (documented trade-off)

## Test plan
- [x] YAML lint clean (\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"\`)
- [ ] After merge + tag, observe the release workflow runs successfully — particularly the deb-signing step and the manifest builder (jq --arg path)
- [ ] \`curl -sL https://github.com/ZerosAndOnesLLC/ezTerm/releases/download/v1.1.3/latest.json | jq .platforms\` shows the 8 entries in the spec-matching order (linux fallback first within each arch block)