### PR TITLE
fix(site): import global.css in custom Astro pages

### DIFF
--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,5 +1,6 @@
 ---
 // site/src/pages/changelog.astro
+import '../styles/global.css';
 import { compareVersionsDesc } from '../lib/version';
 import SiteFooter from '../components/SiteFooter.astro';
 import { marked } from 'marked';

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 // site/src/pages/index.astro
+import '../styles/global.css';
 import Hero from '../components/Hero.astro';
 import MockupFrame from '../components/MockupFrame.astro';
 import FeatureGrid from '../components/FeatureGrid.astro';

--- a/site/src/pages/screenshots.astro
+++ b/site/src/pages/screenshots.astro
@@ -1,5 +1,6 @@
 ---
 // site/src/pages/screenshots.astro
+import '../styles/global.css';
 import MockupFrame from '../components/MockupFrame.astro';
 import SiteFooter from '../components/SiteFooter.astro';
 


### PR DESCRIPTION
## Summary

The deployed landing, changelog, and screenshots pages have no CSS — Starlight docs pages get it via `customCss`, but custom `.astro` pages weren't importing `global.css` themselves, so Tailwind output wasn't bundled into them. Result: bare unstyled HTML on the live site.

Fix: add `import '../styles/global.css';` to the frontmatter of each custom page.

Verified locally:

```
$ grep -oE 'href="[^"]*\.css"' dist/index.html dist/changelog/index.html dist/screenshots/index.html
dist/index.html:href="/ezTerm/_astro/index.BBIDoNml.css"
dist/changelog/index.html:href="/ezTerm/_astro/index.BBIDoNml.css"
dist/screenshots/index.html:href="/ezTerm/_astro/index.BBIDoNml.css"
```

## Test plan

- [ ] After deploy, https://zerosandonesllc.github.io/ezTerm/ renders with the dark theme, hero glow, feature grid cards, etc.
- [ ] `/changelog/` and `/screenshots/` are also styled.
- [ ] `/docs/*` still works (was already fine, but no regression).