### PR TITLE
fix(site): drop Windows-only framing on landing

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -8,7 +8,7 @@ const VERSION = 'v1.3.4'; // bump per release; see plan §commit convention
   <div class="absolute inset-0 pointer-events-none dark-glow" aria-hidden="true"></div>
 
   <div class="relative max-w-5xl mx-auto px-6 pt-24 pb-20">
-    <p class="text-sm font-medium text-site-accent font-mono mb-4">// open-source ssh client for windows</p>
+    <p class="text-sm font-medium text-site-accent font-mono mb-4">// open-source ssh client — windows, linux, macos</p>
     <h1 class="text-5xl md:text-6xl font-bold tracking-tight leading-tight mb-5">
       An SSH client that<br />respects your terminal.
     </h1>
@@ -17,14 +17,17 @@ const VERSION = 'v1.3.4'; // bump per release; see plan §commit convention
       port forwarding, and an encrypted credential vault — all in one tabbed client.
     </p>
 
-    <div class="flex flex-wrap gap-3 items-center">
-      <a
-        href={RELEASES_LATEST}
-        class="inline-flex items-center gap-2 bg-site-accent text-black font-semibold px-5 py-2.5 rounded text-sm hover:brightness-110 transition"
-      >
-        Download for Windows
-        <span class="opacity-60 font-normal">{VERSION}</span>
-      </a>
+    <div class="flex flex-wrap gap-3 items-start">
+      <div class="flex flex-col gap-1">
+        <a
+          href={RELEASES_LATEST}
+          class="inline-flex items-center gap-2 bg-site-accent text-black font-semibold px-5 py-2.5 rounded text-sm hover:brightness-110 transition"
+        >
+          Download
+          <span class="opacity-60 font-normal">{VERSION}</span>
+        </a>
+        <span class="text-xs text-site-fg-muted px-1">Windows · Linux · macOS</span>
+      </div>
       <a
         href={REPO}
         class="inline-flex items-center gap-2 border border-site-border text-site-fg px-5 py-2.5 rounded text-sm hover:bg-site-bg-elevated transition"

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -14,7 +14,7 @@ const BASE = import.meta.env.BASE_URL;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ezTerm — free, open-source SSH client for Windows</title>
+    <title>ezTerm — free, open-source SSH client</title>
     <meta name="description" content="MobaXterm-style sessions, modern Rust core. SSH, SFTP, WSL, X11 forwarding, port forwarding, encrypted vault." />
     <meta property="og:title" content="ezTerm" />
     <meta property="og:description" content="Free, open-source SSH client. MobaXterm-style, modern Rust core." />


### PR DESCRIPTION
## Summary

The landing page advertised ezTerm as Windows-only, but the app runs on Windows, Linux, and macOS.

Changes:
- Page title: `ezTerm — free, open-source SSH client for Windows` → `ezTerm — free, open-source SSH client`
- Hero kicker: `// open-source ssh client for windows` → `// open-source ssh client — windows, linux, macos`
- Hero CTA button: `Download for Windows v1.3.4` → `Download v1.3.4` with a small `Windows · Linux · macOS` line under it

Install tabs section already had all three platforms — no change needed there.

## Test plan

- [ ] After deploy, https://zerosandonesllc.github.io/ezTerm/ no longer says "for Windows" anywhere in the hero area.
- [ ] All three platform labels appear under the Download button.