### PR TITLE
chore: add community health files (CONTRIBUTING, CoC, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something broke or behaved unexpectedly.
+title: "[bug] "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Before submitting, please check
+        [open issues](https://github.com/ZerosAndOnesLLC/ezTerm/issues) for an
+        existing report.
+
+        **Security issue?** Don't post here — see [SECURITY.md](https://github.com/ZerosAndOnesLLC/ezTerm/blob/main/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: ezTerm version
+      description: From Help → About, or `ezterm --version`.
+      placeholder: "v1.3.4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - Linux (specify in details)
+        - macOS (specify version in details)
+        - Other (specify in details)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: session-kind
+    attributes:
+      label: Session kind (if relevant)
+      options:
+        - SSH
+        - SFTP
+        - WSL
+        - Local shell
+        - Vault / credentials
+        - UI / sessions sidebar
+        - Other / N/A
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you did, what you expected, what actually happened.
+      placeholder: |
+        1. Created an SSH session to ...
+        2. Connected and ran ...
+        3. Expected ... but got ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Paste any relevant output from `%LOCALAPPDATA%\ezterm\logs\` (Windows)
+        or `~/.local/share/ezterm/logs/` (Linux/macOS). Redact hostnames,
+        usernames, or other sensitive info before pasting.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, repro repos, related issues, suspected cause.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage question / discussion
+    url: https://github.com/ZerosAndOnesLLC/ezTerm/discussions
+    about: For Q&A, ideas, or anything that isn't a confirmed bug or feature request.
+  - name: Security vulnerability
+    url: https://github.com/ZerosAndOnesLLC/ezTerm/blob/main/SECURITY.md
+    about: Please follow SECURITY.md — do not file public issues for security bugs.
+  - name: Documentation
+    url: https://zerosandonesllc.github.io/ezTerm/docs/
+    about: Docs site — install guide, feature walkthroughs, troubleshooting.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest a new capability or improvement.
+title: "[feat] "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Before submitting, please check
+        [open issues](https://github.com/ZerosAndOnesLLC/ezTerm/issues?q=is%3Aissue+label%3Aenhancement)
+        for an existing request.
+
+        For usage questions or open-ended ideas, prefer
+        [Discussions](https://github.com/ZerosAndOnesLLC/ezTerm/discussions).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Describe the pain point, not the proposed solution. "I want X" works
+        better than "Add a button that does X."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How you'd like ezTerm to behave. UI mockups welcome.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other tools that do this well.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Rough scope
+      options:
+        - Small (single dialog, single feature flag, etc.)
+        - Medium (touches multiple subsystems)
+        - Large (new subsystem, e.g. like SSH port forwarding was)
+        - Not sure
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Link the issue (`Closes #123`) if any. -->
+
+## Test plan
+
+<!-- Checklist of what was verified. Examples:
+- [ ] `cargo check` passes
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
+- [ ] `npm --prefix ui run typecheck && npm --prefix ui run lint`
+- [ ] Manually connected via SSH / WSL / local shell
+- [ ] Screenshots attached for UI changes
+-->
+
+## Notes for reviewers
+
+<!-- Anything that isn't obvious from the diff: design decisions, follow-ups,
+     known limitations, or specific files worth scrutiny. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,91 @@
+# Code of Conduct
+
+## ezTerm
+
+### Contact
+
+For any questions, concerns, or reports regarding this Code of Conduct, please contact: **[support@zerosandones.us](mailto:support@zerosandones.us)**
+
+---
+
+## 1. Purpose
+
+ezTerm is committed to fostering an open, inclusive, and respectful environment for all contributors, users, and community members. This Code of Conduct outlines the expectations for behavior and the steps for reporting unacceptable conduct.
+
+---
+
+## 2. Scope
+
+This Code of Conduct applies to all project spaces, including but not limited to:
+
+* Code repositories
+* Issue trackers
+* Documentation
+* Community forums
+* Events and communications related to ezTerm
+
+It applies to all participants, including maintainers, contributors, and users.
+
+---
+
+## 3. Expected Behavior
+
+Participants are expected to:
+
+* Be respectful and considerate in communication
+* Provide constructive feedback
+* Accept responsibility for mistakes and learn from them
+* Focus on what is best for the community
+* Show empathy towards other community members
+
+---
+
+## 4. Unacceptable Behavior
+
+The following behaviors are not tolerated:
+
+* Harassment, discrimination, or hateful conduct
+* Personal attacks, insults, or derogatory comments
+* Trolling, deliberate provocation, or disruption
+* Sharing private or sensitive information without consent
+* Any conduct that could reasonably be considered inappropriate in a professional setting
+
+---
+
+## 5. Reporting Guidelines
+
+If you experience or witness behavior that violates this Code of Conduct, please report it by contacting:
+
+**[support@zerosandones.us](mailto:support@zerosandones.us)**
+
+When reporting, please include:
+
+* A description of the incident
+* Relevant links or evidence
+* Any additional context that may help
+
+All reports will be handled confidentially and reviewed promptly.
+
+---
+
+## 6. Enforcement
+
+Project maintainers are responsible for enforcing this Code of Conduct. Actions may include:
+
+* Warning the offender
+* Removing or editing content
+* Temporary or permanent bans from the community
+
+Decisions will be made based on the severity and frequency of the violation.
+
+---
+
+## 7. Commitment
+
+The ezTerm team is committed to maintaining a safe and welcoming environment for everyone. We value diversity and inclusivity, and we strive to ensure that all participants feel respected and supported.
+
+---
+
+## 8. License
+
+This Code of Conduct is adapted from common open-source community standards and is provided under the MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to ezTerm
+
+Thanks for considering a contribution. ezTerm is an open-source SSH client
+built with Rust + Tauri; PRs and issues are welcome.
+
+## Before you start
+
+- Browse [open issues](https://github.com/ZerosAndOnesLLC/ezTerm/issues) — if
+  what you want to work on isn't there, open one first so we can agree on
+  shape and scope before code lands.
+- For non-trivial features, expect to write a short spec under
+  `docs/superpowers/specs/` and an implementation plan under
+  `docs/superpowers/plans/` before the code review. The repo's recent feature
+  branches show the pattern.
+- Security-sensitive changes: see [SECURITY.md](SECURITY.md). Don't open
+  public issues for vulnerabilities.
+
+## Dev quickstart
+
+See the [Dev quickstart](README.md#dev-quickstart) section of the README for
+toolchain setup and how to run the app. The short version:
+
+```bash
+cp .env.example .env
+npm --prefix ui install
+cargo tauri dev
+```
+
+## Before opening a PR
+
+- `cargo check` must pass clean (no warnings; remove unused code, don't
+  `#[allow(...)]` past warnings).
+- `cargo test --manifest-path src-tauri/Cargo.toml` passes.
+- `npm --prefix ui run typecheck` and `npm --prefix ui run lint` pass.
+- Bump `Cargo.toml` version per the convention: major = breaking, minor =
+  features, patch = fixes. Site/docs-only commits don't bump.
+- Migrations are added with `sqlx migrate add` so the timestamp is correct,
+  and tested with `sqlx migrate run` before commit.
+
+## Commit messages
+
+Conventional Commits — examples from recent history:
+
+- `feat(ssh-forwards): EADDRINUSE friendly msg, async-error toasts`
+- `fix(site): use relative markdown links for internal doc cross-references`
+- `docs(release-notes): v1.3.4`
+- `sec(ssh-forwards): bind_addr parse-check at save`
+
+No `Co-Authored-By` or "Made with X" attribution in commit messages.
+
+## UI changes
+
+ezTerm's look-and-feel target is **MobaXterm** — left Sessions sidebar,
+tabbed terminal area, optional SFTP side-pane, dark by default with a light
+toggle. Conventions, tokens, and component patterns live in
+`docs/design/`. Match existing styles; don't introduce new visual languages
+without an explicit design update.
+
+## Site / docs changes
+
+The public site (`site/`) is Astro + Starlight. See
+[`site/README.md`](site/README.md) for the dev loop. Docs land at
+[ezterm gh-pages site](https://zerosandonesllc.github.io/ezTerm/docs/).
+
+## Questions
+
+Open a [Discussion](https://github.com/ZerosAndOnesLLC/ezTerm/discussions)
+for usage Q&A or feature ideas, an [Issue](https://github.com/ZerosAndOnesLLC/ezTerm/issues)
+for confirmed bugs.


### PR DESCRIPTION
## Summary

Standard community files to round out the public repo:

- `CONTRIBUTING.md` — dev quickstart pointer, commit conventions, where specs/plans live.
- `CODE_OF_CONDUCT.md` — adapted from the ZerosAndOnes CoC used in `AiFw` etc., contact `support@zerosandones.us`.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form (version, OS, session kind, repro, logs).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured form (problem, proposal, alternatives, scope).
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links Discussions / SECURITY.md / docs site as alternative contact points.
- `.github/pull_request_template.md` — Summary / Test plan / Notes-for-reviewers skeleton.

Companion (already applied via `gh repo edit`): homepage URL set to the GH Pages site, 9 topics added (ssh, ssh-client, sftp, mobaxterm, rust, tauri, wsl, x11, port-forwarding), Wiki disabled (replaced by the docs site), Discussions enabled.

## Test plan

- [ ] Issue templates render in the GitHub UI (try **Issues → New issue** after merge).
- [ ] PR template loads when opening a new PR.
- [ ] GitHub's "community profile" page shows the checkmarks for Description, README, Code of conduct, Contributing, License, Security policy, Issue templates, PR template.