### PR TITLE
chore(site): add Google Search Console verification file

### DIFF
--- a/site/public/google09831d2cb0b33f4b.html
+++ b/site/public/google09831d2cb0b33f4b.html
@@ -1,0 +1,1 @@
+google-site-verification: google09831d2cb0b33f4b.html


### PR DESCRIPTION
## Summary

Adds the Google Search Console site-verification file at `site/public/google09831d2cb0b33f4b.html`. Astro emits everything under `public/` to the root of the build, so once deployed it'll be reachable at:

`https://zerosandonesllc.github.io/ezTerm/google09831d2cb0b33f4b.html`

Same token used on other ZerosAndOnes properties.

## Test plan

- [ ] After deploy, `curl https://zerosandonesllc.github.io/ezTerm/google09831d2cb0b33f4b.html` returns `google-site-verification: google09831d2cb0b33f4b.html`.
- [ ] Re-run verification in Google Search Console and confirm it succeeds.