### PR TITLE
fix(site): make /sitemap.xml resolve + add robots.txt

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build && cp dist/sitemap-index.xml dist/sitemap.xml",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run"

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://zerosandonesllc.github.io/ezTerm/sitemap.xml


### PR DESCRIPTION
## Summary

`@astrojs/sitemap` emits `sitemap-index.xml`, but most SEO tools, crawlers, and Google Search Console expect `/sitemap.xml`. Two changes:

- `site/package.json`: build script copies `dist/sitemap-index.xml` → `dist/sitemap.xml` after `astro build`, so both URLs resolve.
- `site/public/robots.txt`: new file pointing crawlers at `https://zerosandonesllc.github.io/ezTerm/sitemap.xml`.

Verified locally — both `dist/sitemap.xml` and `dist/sitemap-index.xml` exist after `npm run build`, and `dist/robots.txt` ships with the right `Sitemap:` line.

## Test plan

- [ ] After deploy: `curl -I https://zerosandonesllc.github.io/ezTerm/sitemap.xml` returns 200.
- [ ] `curl https://zerosandonesllc.github.io/ezTerm/robots.txt` shows the Sitemap line.
- [ ] Re-submit the sitemap in Google Search Console using the standard `/sitemap.xml` URL.