### PR TITLE
fix(site): correct github.io hostname typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ on those platforms.
 
 ## Website
 
-Project site: <https://zerosandoneslc.github.io/ezTerm/> — landing page, docs,
+Project site: <https://zerosandonesllc.github.io/ezTerm/> — landing page, docs,
 screenshots, and changelog. Source lives in [`site/`](site/).
 
 Develop locally:

--- a/docs/superpowers/plans/2026-05-12-gh-pages-site.md
+++ b/docs/superpowers/plans/2026-05-12-gh-pages-site.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship a polished marketing + docs site for ezTerm at `https://zerosandoneslc.github.io/ezTerm/`, built with Astro 5 + Starlight under `site/` and auto-deployed via GitHub Actions on every push to `main`.
+**Goal:** Ship a polished marketing + docs site for ezTerm at `https://zerosandonesllc.github.io/ezTerm/`, built with Astro 5 + Starlight under `site/` and auto-deployed via GitHub Actions on every push to `main`.
 
 **Architecture:** A new `site/` Astro project sits parallel to `ui/` and `src-tauri/`. A custom `index.astro` is the landing page (overrides Starlight's default home); Starlight handles all `/docs/*` routes with sidebar nav and Pagefind search; one custom page each for `/screenshots/`, `/changelog/`, and `/download/`. The changelog reads `../docs/release-notes/*.md` via an Astro content collection with a glob loader, parses semver from the filename, and sorts numerically (so `v1.10.0` ranks above `v1.3.4`). A new `.github/workflows/site.yml` builds and deploys via `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`.
 
@@ -192,7 +192,7 @@ import starlight from '@astrojs/starlight';
 import tailwind from '@astrojs/tailwind';
 
 export default defineConfig({
-  site: 'https://zerosandoneslc.github.io',
+  site: 'https://zerosandonesllc.github.io',
   base: '/ezTerm/',
   trailingSlash: 'ignore',
   integrations: [
@@ -1932,7 +1932,7 @@ Open `/home/mack/dev/ezTerm/README.md`. Find the existing "Install" heading. Ins
 ```markdown
 ## Website
 
-Project site: <https://zerosandoneslc.github.io/ezTerm/> — landing page, docs,
+Project site: <https://zerosandonesllc.github.io/ezTerm/> — landing page, docs,
 screenshots, and changelog. Source lives in [`site/`](site/).
 
 Develop locally:
@@ -2046,7 +2046,7 @@ Add a note to the rollout PR / release announcement so a maintainer knows to do 
 > 2. Under **Build and deployment → Source**, select **GitHub Actions**.
 > 3. Trigger the workflow once via **Actions → Deploy site to Pages → Run workflow** (or push a doc change).
 > 4. After the first successful deploy, the site is live at
->    <https://zerosandoneslc.github.io/ezTerm/>.
+>    <https://zerosandonesllc.github.io/ezTerm/>.
 
 This step is not automatable from a PR — it requires admin access to repo settings.
 

--- a/docs/superpowers/specs/2026-05-12-gh-pages-site-design.md
+++ b/docs/superpowers/specs/2026-05-12-gh-pages-site-design.md
@@ -7,7 +7,7 @@ Actions, and replaces the README as the canonical user-facing landing page.
 ## Goal
 
 Give ezTerm a polished public presence at
-`https://zerosandoneslc.github.io/ezTerm/` that:
+`https://zerosandonesllc.github.io/ezTerm/` that:
 
 1. Pitches the product to first-time visitors (hero + screenshots + download).
 2. Walks new users through install and first connect.
@@ -28,7 +28,7 @@ versioned docs for old releases.
 | Stack                | Astro 5 + Starlight + Tailwind CSS.                                                     |
 | Visual direction     | Direction "B" — developer/terminal aesthetic. Deep black, cyan-blue accent, mono motifs.|
 | Theme                | Dark default with light-mode toggle (Starlight default).                                |
-| URL                  | GitHub Pages default `zerosandoneslc.github.io/ezTerm/`. Custom domain deferred.        |
+| URL                  | GitHub Pages default `zerosandonesllc.github.io/ezTerm/`. Custom domain deferred.        |
 | Pages source         | "GitHub Actions" mode (modern path; no `gh-pages` branch).                              |
 | Source location      | `site/` at repo root, parallel to `ui/` and `src-tauri/`.                               |
 | Fonts                | Inter (body) + JetBrains Mono (code/terminal). Self-hosted via `@fontsource`.           |
@@ -179,7 +179,7 @@ import starlight from '@astrojs/starlight';
 import tailwind from '@astrojs/tailwind';
 
 export default defineConfig({
-  site: 'https://zerosandoneslc.github.io',
+  site: 'https://zerosandonesllc.github.io',
   base: '/ezTerm/',
   trailingSlash: 'ignore',
   integrations: [

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,7 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
 export default defineConfig({
-  site: 'https://zerosandoneslc.github.io',
+  site: 'https://zerosandonesllc.github.io',
   base: '/ezTerm/',
   trailingSlash: 'ignore',
   vite: {


### PR DESCRIPTION
## Summary

`astro.config.mjs` had `site: 'https://zerosandoneslc.github.io'` — missing one of the two L's in "LLC". The site loads at the correct host (`zerosandonesllc.github.io`) because GitHub Pages serves it directly, but every absolute URL Astro generates uses the typo'd hostname.

Concrete impact found via Google Search Console: the sitemap loads, but every `<loc>` inside points at a host that 404s, so Google rejects the URLs as unreachable.

Before:
```xml
<loc>https://zerosandoneslc.github.io/ezTerm/sitemap-0.xml</loc>
```

After:
```xml
<loc>https://zerosandonesllc.github.io/ezTerm/sitemap-0.xml</loc>
```

Fixed across four files: `site/astro.config.mjs` (the source of truth), `README.md` (Website section link), and the two historical design docs under `docs/superpowers/` so future readers don't copy the typo.

## Test plan

- [ ] After deploy: `curl https://zerosandonesllc.github.io/ezTerm/sitemap.xml | grep '<loc>'` shows `zerosandonesllc` (double L) in every entry.
- [ ] Re-submit the sitemap in Google Search Console — Google should now be able to crawl all 17 URLs.