### PR TITLE
fix(sidebar): reliable session-into-folder DnD + move/sort context items (#72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "argon2",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "argon2",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.3.5"
+version = "1.3.6"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.3.6"
+version = "1.3.7"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/docs/release-notes/v1.3.7.md
+++ b/docs/release-notes/v1.3.7.md
@@ -1,0 +1,24 @@
+# ezTerm v1.3.7
+
+Patch: drag-and-drop in the sessions sidebar now actually moves items. PR #72 added the right context-menu hit zones and the "Move to folder…" right-click path, but the underlying drag flow was still broken — dragging a session onto a folder grayed the source row and then silently did nothing.
+
+## What changed
+
+- **`ui/components/sessions-sidebar.tsx`** — `NodeView` is hoisted out of `SessionsSidebar`. The component-inside-component pattern gave `NodeView` a fresh function identity on every `setState`, so each `dragover` → `setDragTarget` re-render caused React to unmount + remount the whole tree. That ripped the drag-source DOM element out from under the browser, which then aborted the in-flight HTML5 drag — `dragover` and `drop` never fired again, and the move never happened.
+- `NodeView` now lives at module scope and takes a single `ctx` prop bundling the state and handlers it needs (`expanded`, `drag`, `dragTarget`, `selectedId`, `connectedSessionIds`, the `handle*` drag callbacks, `slotForRow`, `toggleFolder`, the menu openers, `setConfirm`, `setSelectedId`, `openTabAction`). The `ctx` object is rebuilt each render, but `NodeView`'s identity is stable — React reconciles props instead of remounting.
+
+The right-click "Move to folder…" path was unaffected by the bug and remains the same — it doesn't depend on a long-lived DOM element across re-renders, which is why it worked while drag-and-drop didn't.
+
+## Other
+
+- Synced version across `Cargo.toml`, `src-tauri/tauri.conf.json`, `ui/package.json`, and the lockfiles. Previously `tauri.conf.json` was pinned at `1.0.2` and `ui/package.json` at `1.1.0`, both stale from earlier merges.
+
+## Verify
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Licence
+
+**GPL v3** (version 3 only). See [LICENSE](../blob/main/LICENSE).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.0.2",
+  "version": "1.3.7",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/components/move-to-folder-dialog.tsx
+++ b/ui/components/move-to-folder-dialog.tsx
@@ -1,0 +1,181 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Folder, FolderOpen } from 'lucide-react';
+import type { Folder as TFolder } from '@/lib/types';
+
+interface Props {
+  title:           string;
+  folders:         TFolder[];
+  /** Folder the item currently lives in. Disabled in the picker so a
+   *  user can't pick the no-op destination. `null` = root. */
+  currentFolderId: number | null;
+  /** Folders that should not be selectable (e.g. moving a folder into
+   *  itself or one of its descendants would be a cycle). */
+  excludedIds?:    Set<number>;
+  confirmText?:    string;
+  onCancel:        () => void;
+  onConfirm:       (folderId: number | null) => void | Promise<void>;
+}
+
+interface Node { folder: TFolder; children: Node[] }
+
+function buildForest(folders: TFolder[]): Node[] {
+  const byParent = new Map<number | null, TFolder[]>();
+  for (const f of folders) {
+    if (!byParent.has(f.parent_id)) byParent.set(f.parent_id, []);
+    byParent.get(f.parent_id)!.push(f);
+  }
+  function build(parent: number | null): Node[] {
+    return (byParent.get(parent) ?? [])
+      .slice()
+      .sort((a, b) => a.sort - b.sort || a.id - b.id)
+      .map((f) => ({ folder: f, children: build(f.id) }));
+  }
+  return build(null);
+}
+
+export function MoveToFolderDialog({
+  title,
+  folders,
+  currentFolderId,
+  excludedIds,
+  confirmText = 'Move',
+  onCancel,
+  onConfirm,
+}: Props) {
+  const forest = useMemo(() => buildForest(folders), [folders]);
+  const [pick, setPick] = useState<number | null | undefined>(undefined);
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set(folders.map((f) => f.id)));
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onCancel(); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  function toggle(id: number) {
+    setExpanded((cur) => {
+      const next = new Set(cur);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (pick === undefined) { setErr('Select a destination folder.'); return; }
+    setErr(null);
+    setBusy(true);
+    try {
+      await onConfirm(pick);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function Row({ node, depth }: { node: Node; depth: number }) {
+    const id = node.folder.id;
+    const isOpen = expanded.has(id);
+    const FolderIcon = isOpen ? FolderOpen : Folder;
+    const disabled = currentFolderId === id || excludedIds?.has(id);
+    const selected = pick === id;
+    return (
+      <div>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setPick(id)}
+          className={`group w-full h-7 flex items-center gap-1.5 px-1.5 text-left text-xs transition-colors ${
+            selected
+              ? 'bg-accent/20 text-fg outline outline-1 outline-accent/60'
+              : disabled
+                ? 'text-muted/60 cursor-not-allowed'
+                : 'text-fg/90 hover:bg-surface2/70'
+          }`}
+          style={{ paddingLeft: 6 + depth * 12 }}
+          title={disabled ? 'Already here' : node.folder.name}
+        >
+          {node.children.length > 0 ? (
+            <span
+              role="button"
+              aria-label={isOpen ? 'Collapse' : 'Expand'}
+              tabIndex={-1}
+              onClick={(e) => { e.stopPropagation(); toggle(id); }}
+              className="w-3 h-3 flex items-center justify-center text-muted/80 shrink-0"
+            >
+              {isOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+            </span>
+          ) : (
+            <span className="w-3 h-3 shrink-0" />
+          )}
+          <FolderIcon size={14} className={`shrink-0 ${isOpen ? 'text-accent' : 'text-accent/70'}`} />
+          <span className="truncate flex-1">{node.folder.name}</span>
+        </button>
+        {isOpen && node.children.map((c) => (
+          <Row key={c.folder.id} node={c} depth={depth + 1} />
+        ))}
+      </div>
+    );
+  }
+
+  const rootDisabled = currentFolderId === null;
+  const rootSelected = pick === null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 overlay-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="move-title"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div className="w-[440px] max-w-full bg-surface border border-border rounded-md shadow-dialog dialog-in">
+        <div className="p-4">
+          <h2 id="move-title" className="font-semibold text-sm">{title}</h2>
+          <div className="mt-3 max-h-[320px] overflow-y-auto rounded-sm border border-border bg-surface2/30 py-1">
+            <button
+              type="button"
+              disabled={rootDisabled}
+              onClick={() => setPick(null)}
+              className={`w-full h-7 flex items-center gap-1.5 px-1.5 text-left text-xs transition-colors ${
+                rootSelected
+                  ? 'bg-accent/20 text-fg outline outline-1 outline-accent/60'
+                  : rootDisabled
+                    ? 'text-muted/60 cursor-not-allowed'
+                    : 'text-fg/90 hover:bg-surface2/70'
+              }`}
+              style={{ paddingLeft: 6 }}
+              title={rootDisabled ? 'Already here' : '(Root)'}
+            >
+              <span className="w-3 h-3 shrink-0" />
+              <Folder size={14} className="shrink-0 text-muted" />
+              <span className="truncate flex-1 italic">(Root)</span>
+            </button>
+            {forest.map((n) => (<Row key={n.folder.id} node={n} depth={0} />))}
+          </div>
+          {err && <div className="text-danger text-xs mt-2">{err}</div>}
+        </div>
+        <div className="px-4 py-3 border-t border-border bg-surface2/30 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 border border-border rounded text-sm hover:bg-surface2 focus-ring"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={busy || pick === undefined}
+            className="px-3 py-1.5 bg-accent text-white rounded text-sm font-medium hover:brightness-110 disabled:opacity-50 focus-ring"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/sessions-sidebar.tsx
+++ b/ui/components/sessions-sidebar.tsx
@@ -51,6 +51,7 @@ import { ImportMobaxtermDialog } from './import-mobaxterm-dialog';
 import { BackupDialog } from './backup-dialog';
 import { RestoreDialog } from './restore-dialog';
 import { SyncDialog } from './sync-dialog';
+import { MoveToFolderDialog } from './move-to-folder-dialog';
 
 interface TreeNode {
   folder: TFolder | null; // null = root
@@ -141,6 +142,8 @@ export function SessionsSidebar() {
   const [backupOpen, setBackupOpen] = useState(false);
   const [restorePath, setRestorePath] = useState<string | null>(null);
   const [syncOpen, setSyncOpen] = useState(false);
+  const [moveSession, setMoveSession] = useState<Session | null>(null);
+  const [moveFolder, setMoveFolder] = useState<TFolder | null>(null);
   // Drag-and-drop state: `drag` is the row being dragged (opacity-50 on the
   // source); `dragTarget` is the hovered drop slot — see `DropSlot` below.
   // null when nothing is being dragged-over. Slots describe *where* the
@@ -200,17 +203,27 @@ export function SessionsSidebar() {
   function openFolderMenu(e: React.MouseEvent, f: TFolder | null) {
     e.preventDefault();
     const id = f?.id ?? null;
+    const hasChildrenToSort =
+      folders.filter((x) => x.parent_id === id).length
+      + sessions.filter((s) => s.folder_id === id).length
+      > 1;
     const items: MenuItem[] = [
       { label: 'New Session', onClick: () => setDialog({ mode: 'create', folderId: id }) },
       { label: 'New Folder', onClick: () => setPrompt({ kind: 'new-folder', parentId: id }) },
+      { separator: true },
+      { label: 'Sort A \u2192 Z', disabled: !hasChildrenToSort, onClick: () => sortChildren(id, 'asc') },
+      { label: 'Sort Z \u2192 A', disabled: !hasChildrenToSort, onClick: () => sortChildren(id, 'desc') },
     ];
     if (f) {
       items.push(
+        { separator: true },
+        { label: 'Move to folder\u2026', onClick: () => setMoveFolder(f) },
         { label: 'Rename', onClick: () => setPrompt({ kind: 'rename-folder', folder: f }) },
         { label: 'Delete', danger: true, onClick: () => setConfirm({ kind: 'delete-folder', folder: f }) },
       );
     } else {
       items.push(
+        { separator: true },
         { label: 'Import from MobaXterm\u2026', onClick: pickMobaXtermFile },
         { separator: true },
         { label: 'Backup\u2026',  onClick: () => setBackupOpen(true) },
@@ -220,6 +233,59 @@ export function SessionsSidebar() {
       );
     }
     setMenu({ x: e.clientX, y: e.clientY, items });
+  }
+
+  /** Sort a folder's *immediate* children alphabetically. Folders and
+   *  sessions are sorted independently \u2014 folders stay rendered above
+   *  sessions per the existing tree layout. `null` parent = root. */
+  async function sortChildren(parentId: number | null, dir: 'asc' | 'desc') {
+    const cmp = (a: string, b: string) => {
+      const c = a.localeCompare(b, undefined, { sensitivity: 'base' });
+      return dir === 'asc' ? c : -c;
+    };
+    const childFolders = folders
+      .filter((x) => x.parent_id === parentId)
+      .slice()
+      .sort((a, b) => cmp(a.name, b.name));
+    const childSessions = sessions
+      .filter((s) => s.folder_id === parentId)
+      .slice()
+      .sort((a, b) => cmp(a.name, b.name));
+    if (childFolders.length <= 1 && childSessions.length <= 1) return;
+
+    await run(async () => {
+      const ops: Promise<void>[] = [];
+      if (childFolders.length > 1) {
+        ops.push(api.folderReorder(parentId, childFolders.map((f) => f.id)));
+      }
+      if (childSessions.length > 1) {
+        ops.push(api.sessionReorder(parentId, childSessions.map((s) => s.id)));
+      }
+      await Promise.all(ops);
+    });
+    reload();
+    toast.success('Sorted', dir === 'asc' ? 'A \u2192 Z' : 'Z \u2192 A');
+  }
+
+  /** Folder ids that would create a cycle if used as `f`'s new parent \u2014
+   *  i.e. `f` itself plus every descendant. Used by the move-folder
+   *  picker to disable invalid destinations. */
+  function descendantFolderIds(f: TFolder): Set<number> {
+    const out = new Set<number>([f.id]);
+    let frontier = [f.id];
+    while (frontier.length > 0) {
+      const next: number[] = [];
+      for (const pid of frontier) {
+        for (const child of folders) {
+          if (child.parent_id === pid && !out.has(child.id)) {
+            out.add(child.id);
+            next.push(child.id);
+          }
+        }
+      }
+      frontier = next;
+    }
+    return out;
   }
 
   async function pickRestoreFile() {
@@ -291,9 +357,18 @@ export function SessionsSidebar() {
     if (!slotsEqual(dragTarget, next)) setDragTarget(next);
   }
 
-  /** Compute the slot for a row-aware drag: sessions split 50/50 above/below,
-   *  folder rows split 25% / 50% / 25% into above / into / below so users
-   *  can both reorder siblings *and* drop into a folder from the same row. */
+  /** Compute the slot for a row-aware drag.
+   *
+   *  Sessions split 50/50 above/below for sibling reorder.
+   *
+   *  Folder rows depend on the drag source:
+   *  - **Folder source**: split 25 / 50 / 25 (above / into / below) so a
+   *    user can both nest one folder inside another *and* reorder folders
+   *    from the same row.
+   *  - **Session source**: the entire row is `into-folder`. Reordering a
+   *    folder by dropping a session next to it isn't a real use case, and
+   *    the narrow ~14px middle band (25% of a 28px row) made dropping a
+   *    session *into* a folder feel broken — see #72. */
   function slotForRow(
     e: React.DragEvent,
     row: 'session' | 'folder',
@@ -306,6 +381,9 @@ export function SessionsSidebar() {
       return ratio < 0.5
         ? { kind: 'before-session', sessionId: id }
         : { kind: 'after-session', sessionId: id };
+    }
+    if (dragSourceRef.current?.kind === 'session') {
+      return { kind: 'into-folder', folderId: id };
     }
     if (ratio < 0.25) return { kind: 'before-folder', folderId: id };
     if (ratio > 0.75) return { kind: 'after-folder', folderId: id };
@@ -507,6 +585,9 @@ export function SessionsSidebar() {
             reload();
           },
         },
+        { separator: true },
+        { label: 'Move to folder…', onClick: () => setMoveSession(s) },
+        { separator: true },
         { label: 'Delete', danger: true, onClick: () => setConfirm({ kind: 'delete-session', session: s }) },
       ],
     });
@@ -894,6 +975,45 @@ export function SessionsSidebar() {
             } else {
               toast.success('Import complete', body);
             }
+          }}
+        />
+      )}
+
+      {moveSession && (
+        <MoveToFolderDialog
+          title={`Move "${moveSession.name}" to…`}
+          folders={folders}
+          currentFolderId={moveSession.folder_id}
+          onCancel={() => setMoveSession(null)}
+          onConfirm={async (folderId) => {
+            const s = moveSession;
+            await run(() => api.sessionMove(s.id, folderId, 0));
+            setMoveSession(null);
+            if (folderId !== null) {
+              setExpanded((prev) => new Set(prev).add(folderId));
+            }
+            reload();
+            toast.success('Session moved', s.name);
+          }}
+        />
+      )}
+
+      {moveFolder && (
+        <MoveToFolderDialog
+          title={`Move folder "${moveFolder.name}" to…`}
+          folders={folders}
+          currentFolderId={moveFolder.parent_id}
+          excludedIds={descendantFolderIds(moveFolder)}
+          onCancel={() => setMoveFolder(null)}
+          onConfirm={async (parentId) => {
+            const f = moveFolder;
+            await run(() => api.folderMove(f.id, parentId, 0));
+            setMoveFolder(null);
+            if (parentId !== null) {
+              setExpanded((prev) => new Set(prev).add(parentId));
+            }
+            reload();
+            toast.success('Folder moved', f.name);
           }}
         />
       )}

--- a/ui/components/sessions-sidebar.tsx
+++ b/ui/components/sessions-sidebar.tsx
@@ -129,6 +129,200 @@ function slotsEqual(a: DropSlot | null, b: DropSlot | null): boolean {
   }
 }
 
+interface NodeViewCtx {
+  expanded:            Set<number>;
+  drag:                { kind: 'session' | 'folder'; id: number } | null;
+  dragTarget:          DropSlot | null;
+  selectedId:          number | null;
+  connectedSessionIds: Set<number>;
+  handleDragStart:     (e: React.DragEvent, kind: 'session' | 'folder', id: number) => void;
+  handleDragEnd:       () => void;
+  handleDragOver:      (e: React.DragEvent, slot: DropSlot) => void;
+  handleDrop:          (e: React.DragEvent, slot: DropSlot) => Promise<void>;
+  slotForRow:          (e: React.DragEvent, row: 'session' | 'folder', id: number) => DropSlot;
+  toggleFolder:        (id: number) => void;
+  openFolderMenu:      (e: React.MouseEvent, f: TFolder | null) => void;
+  openSessionMenu:     (e: React.MouseEvent, s: Session) => void;
+  setConfirm:          React.Dispatch<React.SetStateAction<PendingConfirm | null>>;
+  setSelectedId:       React.Dispatch<React.SetStateAction<number | null>>;
+  openTabAction:       (s: Session) => void;
+}
+
+// Top-level so the function identity is stable across SessionsSidebar
+// re-renders. If NodeView were defined inside SessionsSidebar, every
+// setState would give it a new identity and React would unmount + remount
+// the whole tree — which aborts in-flight HTML5 drags by ripping the
+// source DOM out from under the browser.
+function NodeView({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: NodeViewCtx }) {
+  const isOpen = node.folder ? ctx.expanded.has(node.folder.id) : true;
+  const FolderIcon = isOpen ? FolderOpen : Folder;
+  const isDragSource = !!(
+    node.folder && ctx.drag?.kind === 'folder' && ctx.drag.id === node.folder.id
+  );
+  const isIntoTarget =
+    node.folder != null
+    && ctx.dragTarget?.kind === 'into-folder'
+    && ctx.dragTarget.folderId === node.folder.id;
+  const hasBeforeEdge =
+    node.folder != null
+    && ctx.dragTarget?.kind === 'before-folder'
+    && ctx.dragTarget.folderId === node.folder.id;
+  const hasAfterEdge =
+    node.folder != null
+    && ctx.dragTarget?.kind === 'after-folder'
+    && ctx.dragTarget.folderId === node.folder.id;
+  const sessionCount = countDescendantSessions(node);
+  return (
+    <div>
+      {node.folder && (
+        <div
+          draggable
+          onDragStart={(e) => ctx.handleDragStart(e, 'folder', node.folder!.id)}
+          onDragEnd={ctx.handleDragEnd}
+          onDragOver={(e) => ctx.handleDragOver(e, ctx.slotForRow(e, 'folder', node.folder!.id))}
+          onDrop={(e) => ctx.handleDrop(e, ctx.slotForRow(e, 'folder', node.folder!.id))}
+          onClick={() => ctx.toggleFolder(node.folder!.id)}
+          onContextMenu={(e) => ctx.openFolderMenu(e, node.folder!)}
+          className={`group relative h-7 flex items-center gap-1.5 cursor-default select-none pr-2 transition-colors ${
+            isIntoTarget
+              ? 'bg-accent/20 outline outline-1 outline-accent/60 text-fg'
+              : 'text-fg/80 hover:text-fg hover:bg-surface2/70'
+          } ${isDragSource ? 'opacity-50' : ''}`}
+          style={{ paddingLeft: 6 + depth * 12 }}
+          role="treeitem"
+          aria-expanded={isOpen}
+          aria-selected={false}
+        >
+          {hasBeforeEdge && <DropLine edge="top" />}
+          {hasAfterEdge  && <DropLine edge="bottom" />}
+          <span className="w-3 h-3 flex items-center justify-center text-muted/80 shrink-0">
+            {isOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          </span>
+          <FolderIcon
+            size={14}
+            className={`shrink-0 ${isOpen ? 'text-accent' : 'text-accent/70'}`}
+            strokeWidth={2}
+          />
+          <span className="truncate text-xs font-medium flex-1">{node.folder.name}</span>
+          {sessionCount > 0 && (
+            <span
+              className="shrink-0 text-[10px] font-mono tabular-nums px-1.5 py-[1px] rounded-sm bg-surface2/80 text-muted group-hover:bg-surface2 group-hover:text-fg/80"
+              title={`${sessionCount} session${sessionCount === 1 ? '' : 's'}`}
+            >
+              {sessionCount}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              ctx.setConfirm({ kind: 'delete-folder', folder: node.folder! });
+            }}
+            aria-label={`Delete folder ${node.folder.name}`}
+            title="Delete folder"
+            className="shrink-0 w-5 h-5 flex items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 text-muted hover:text-danger hover:bg-danger/10"
+          >
+            <Trash2 size={11} />
+          </button>
+        </div>
+      )}
+      {isOpen && (
+        <>
+          {/* Folders BEFORE sessions at every depth (implementation-notes §2). */}
+          {node.folders.map((child) => (
+            <NodeView key={child.folder!.id} node={child} depth={depth + 1} ctx={ctx} />
+          ))}
+          {node.sessions.map((s) => {
+            const isSelected  = ctx.selectedId === s.id;
+            const isConnected = ctx.connectedSessionIds.has(s.id);
+            const isSrc = ctx.drag?.kind === 'session' && ctx.drag.id === s.id;
+            const sessionHasBefore = ctx.dragTarget?.kind === 'before-session' && ctx.dragTarget.sessionId === s.id;
+            const sessionHasAfter  = ctx.dragTarget?.kind === 'after-session'  && ctx.dragTarget.sessionId === s.id;
+            // Left-rail colour priority: connected green > selected accent
+            // > session's own colour > transparent.
+            const rail = isConnected
+              ? 'rgb(var(--success))'
+              : isSelected
+                ? 'rgb(var(--accent))'
+                : s.color ?? 'transparent';
+            return (
+              <div
+                key={s.id}
+                draggable
+                onDragStart={(e) => ctx.handleDragStart(e, 'session', s.id)}
+                onDragEnd={ctx.handleDragEnd}
+                onClick={() => ctx.setSelectedId(s.id)}
+                onContextMenu={(e) => ctx.openSessionMenu(e, s)}
+                onDoubleClick={() => ctx.openTabAction(s)}
+                onDragOver={(e) => {
+                  if (!ctx.drag) return;
+                  // Split the row 50/50: top half places the dragged item
+                  // *before* this session, bottom half *after*. Works for
+                  // both same-folder reordering and cross-folder moves
+                  // (the drop handler resolves destFolderId from the
+                  // anchor session's folder).
+                  ctx.handleDragOver(e, ctx.slotForRow(e, 'session', s.id));
+                }}
+                onDrop={(e) => {
+                  if (!ctx.drag) return;
+                  ctx.handleDrop(e, ctx.slotForRow(e, 'session', s.id));
+                }}
+                className={`group relative h-7 flex items-center gap-2 cursor-default select-none pr-2 transition-colors ${
+                  isSelected
+                    ? 'bg-accent/18 text-fg'
+                    : 'hover:bg-surface2/70 text-fg/90 hover:text-fg'
+                } ${isSrc ? 'opacity-50' : ''}`}
+                style={{ paddingLeft: 6 + (depth + 1) * 12 }}
+                role="treeitem"
+                aria-selected={isSelected}
+                title={`${s.username}@${s.host}${s.port !== 22 ? `:${s.port}` : ''}`}
+              >
+                {sessionHasBefore && <DropLine edge="top" />}
+                {sessionHasAfter  && <DropLine edge="bottom" />}
+                <span
+                  className={`absolute left-0 top-1 bottom-1 w-[3px] rounded-r-sm ${
+                    isConnected ? 'animate-pulse' : ''
+                  }`}
+                  style={{ background: rail }}
+                  aria-hidden
+                />
+                {(() => {
+                  const KindIcon =
+                    s.session_kind === 'wsl' ? SquareTerminal :
+                    s.session_kind === 'local' ? MonitorDot :
+                    Server;
+                  // Tile priority: connected green > per-session colour >
+                  // kind default. Keeps user branding visible when idle,
+                  // flips to a clear "live" signal while connected.
+                  const tileBg = isConnected
+                    ? 'rgb(var(--success))'
+                    : (s.color ?? KIND_DEFAULT_TILE[s.session_kind]);
+                  return (
+                    <span
+                      className="shrink-0 w-[18px] h-[18px] rounded-sm flex items-center justify-center"
+                      style={{ background: tileBg }}
+                      aria-hidden
+                    >
+                      <KindIcon
+                        size={11}
+                        className="text-white"
+                        strokeWidth={2.25}
+                      />
+                    </span>
+                  );
+                })()}
+                <span className={`truncate text-xs flex-1 ${isSelected ? 'font-medium' : ''}`}>
+                  {s.name}
+                </span>
+              </div>
+            );
+          })}
+        </>
+      )}
+    </div>
+  );
+}
+
 export function SessionsSidebar() {
   const [folders, setFolders] = useState<TFolder[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -593,176 +787,30 @@ export function SessionsSidebar() {
     });
   }
 
-  function NodeView({ node, depth }: { node: TreeNode; depth: number }) {
-    const isOpen = node.folder ? expanded.has(node.folder.id) : true;
-    const FolderIcon = isOpen ? FolderOpen : Folder;
-    const folderId = node.folder?.id ?? null;
-    const isDragSource = !!(
-      node.folder && drag?.kind === 'folder' && drag.id === node.folder.id
-    );
-    const isIntoTarget =
-      node.folder != null
-      && dragTarget?.kind === 'into-folder'
-      && dragTarget.folderId === node.folder.id;
-    const hasBeforeEdge =
-      node.folder != null
-      && dragTarget?.kind === 'before-folder'
-      && dragTarget.folderId === node.folder.id;
-    const hasAfterEdge =
-      node.folder != null
-      && dragTarget?.kind === 'after-folder'
-      && dragTarget.folderId === node.folder.id;
-    const sessionCount = countDescendantSessions(node);
-    return (
-      <div>
-        {node.folder && (
-          <div
-            draggable
-            onDragStart={(e) => handleDragStart(e, 'folder', node.folder!.id)}
-            onDragEnd={handleDragEnd}
-            onDragOver={(e) => handleDragOver(e, slotForRow(e, 'folder', node.folder!.id))}
-            onDrop={(e) => handleDrop(e, slotForRow(e, 'folder', node.folder!.id))}
-            onClick={() => toggleFolder(node.folder!.id)}
-            onContextMenu={(e) => openFolderMenu(e, node.folder!)}
-            className={`group relative h-7 flex items-center gap-1.5 cursor-default select-none pr-2 transition-colors ${
-              isIntoTarget
-                ? 'bg-accent/20 outline outline-1 outline-accent/60 text-fg'
-                : 'text-fg/80 hover:text-fg hover:bg-surface2/70'
-            } ${isDragSource ? 'opacity-50' : ''}`}
-            style={{ paddingLeft: 6 + depth * 12 }}
-            role="treeitem"
-            aria-expanded={isOpen}
-            aria-selected={false}
-          >
-            {hasBeforeEdge && <DropLine edge="top" />}
-            {hasAfterEdge  && <DropLine edge="bottom" />}
-            <span className="w-3 h-3 flex items-center justify-center text-muted/80 shrink-0">
-              {isOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
-            </span>
-            <FolderIcon
-              size={14}
-              className={`shrink-0 ${isOpen ? 'text-accent' : 'text-accent/70'}`}
-              strokeWidth={2}
-            />
-            <span className="truncate text-xs font-medium flex-1">{node.folder.name}</span>
-            {sessionCount > 0 && (
-              <span
-                className="shrink-0 text-[10px] font-mono tabular-nums px-1.5 py-[1px] rounded-sm bg-surface2/80 text-muted group-hover:bg-surface2 group-hover:text-fg/80"
-                title={`${sessionCount} session${sessionCount === 1 ? '' : 's'}`}
-              >
-                {sessionCount}
-              </span>
-            )}
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                setConfirm({ kind: 'delete-folder', folder: node.folder! });
-              }}
-              aria-label={`Delete folder ${node.folder.name}`}
-              title="Delete folder"
-              className="shrink-0 w-5 h-5 flex items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 text-muted hover:text-danger hover:bg-danger/10"
-            >
-              <Trash2 size={11} />
-            </button>
-          </div>
-        )}
-        {isOpen && (
-          <>
-            {/* Folders BEFORE sessions at every depth (implementation-notes §2). */}
-            {node.folders.map((child) => (
-              <NodeView key={child.folder!.id} node={child} depth={depth + 1} />
-            ))}
-            {node.sessions.map((s) => {
-              const isSelected  = selectedId === s.id;
-              const isConnected = connectedSessionIds.has(s.id);
-              const isSrc = drag?.kind === 'session' && drag.id === s.id;
-              const sessionHasBefore = dragTarget?.kind === 'before-session' && dragTarget.sessionId === s.id;
-              const sessionHasAfter  = dragTarget?.kind === 'after-session'  && dragTarget.sessionId === s.id;
-              // Left-rail colour priority: connected green > selected accent
-              // > session's own colour > transparent.
-              const rail = isConnected
-                ? 'rgb(var(--success))'
-                : isSelected
-                  ? 'rgb(var(--accent))'
-                  : s.color ?? 'transparent';
-              return (
-                <div
-                  key={s.id}
-                  draggable
-                  onDragStart={(e) => handleDragStart(e, 'session', s.id)}
-                  onDragEnd={handleDragEnd}
-                  onClick={() => setSelectedId(s.id)}
-                  onContextMenu={(e) => openSessionMenu(e, s)}
-                  onDoubleClick={() => openTabAction(s)}
-                  onDragOver={(e) => {
-                    if (!drag) return;
-                    // Split the row 50/50: top half places the dragged item
-                    // *before* this session, bottom half *after*. Works for
-                    // both same-folder reordering and cross-folder moves
-                    // (the drop handler resolves destFolderId from the
-                    // anchor session's folder).
-                    handleDragOver(e, slotForRow(e, 'session', s.id));
-                  }}
-                  onDrop={(e) => {
-                    if (!drag) return;
-                    handleDrop(e, slotForRow(e, 'session', s.id));
-                  }}
-                  className={`group relative h-7 flex items-center gap-2 cursor-default select-none pr-2 transition-colors ${
-                    isSelected
-                      ? 'bg-accent/18 text-fg'
-                      : 'hover:bg-surface2/70 text-fg/90 hover:text-fg'
-                  } ${isSrc ? 'opacity-50' : ''}`}
-                  style={{ paddingLeft: 6 + (depth + 1) * 12 }}
-                  role="treeitem"
-                  aria-selected={isSelected}
-                  title={`${s.username}@${s.host}${s.port !== 22 ? `:${s.port}` : ''}`}
-                >
-                  {sessionHasBefore && <DropLine edge="top" />}
-                  {sessionHasAfter  && <DropLine edge="bottom" />}
-                  <span
-                    className={`absolute left-0 top-1 bottom-1 w-[3px] rounded-r-sm ${
-                      isConnected ? 'animate-pulse' : ''
-                    }`}
-                    style={{ background: rail }}
-                    aria-hidden
-                  />
-                  {(() => {
-                    const KindIcon =
-                      s.session_kind === 'wsl' ? SquareTerminal :
-                      s.session_kind === 'local' ? MonitorDot :
-                      Server;
-                    // Tile priority: connected green > per-session colour >
-                    // kind default. Keeps user branding visible when idle,
-                    // flips to a clear "live" signal while connected.
-                    const tileBg = isConnected
-                      ? 'rgb(var(--success))'
-                      : (s.color ?? KIND_DEFAULT_TILE[s.session_kind]);
-                    return (
-                      <span
-                        className="shrink-0 w-[18px] h-[18px] rounded-sm flex items-center justify-center"
-                        style={{ background: tileBg }}
-                        aria-hidden
-                      >
-                        <KindIcon
-                          size={11}
-                          className="text-white"
-                          strokeWidth={2.25}
-                        />
-                      </span>
-                    );
-                  })()}
-                  <span className={`truncate text-xs flex-1 ${isSelected ? 'font-medium' : ''}`}>
-                    {s.name}
-                  </span>
-                </div>
-              );
-            })}
-          </>
-        )}
-      </div>
-    );
-  }
+  // Bundle everything NodeView needs from this component's scope. NodeView
+  // itself is hoisted to module scope (below SessionsSidebar) so its
+  // function identity stays stable across renders — defining it inline
+  // would cause React to unmount + remount the entire tree on every
+  // setState (e.g. dragover → setDragTarget), which aborts in-flight
+  // HTML5 drags by ripping the source DOM out from under the browser.
+  const nodeViewCtx: NodeViewCtx = {
+    expanded,
+    drag,
+    dragTarget,
+    selectedId,
+    connectedSessionIds,
+    handleDragStart,
+    handleDragEnd,
+    handleDragOver,
+    handleDrop,
+    slotForRow,
+    toggleFolder,
+    openFolderMenu,
+    openSessionMenu,
+    setConfirm,
+    setSelectedId,
+    openTabAction,
+  };
 
   const empty = folders.length === 0 && sessions.length === 0;
 
@@ -834,7 +882,7 @@ export function SessionsSidebar() {
             compact
           />
         ) : (
-          <NodeView node={tree} depth={0} />
+          <NodeView node={tree} depth={0} ctx={nodeViewCtx} />
         )}
       </div>
 

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ezterm-ui",
-  "version": "1.1.0",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ezterm-ui",
-      "version": "1.1.0",
+      "version": "1.3.7",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-clipboard-manager": "^2",
@@ -81,6 +81,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1710,6 +1711,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1769,6 +1771,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2269,6 +2272,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2654,6 +2658,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3230,6 +3235,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3370,6 +3376,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5622,6 +5629,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5696,6 +5704,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5705,6 +5714,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6396,6 +6406,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6558,6 +6569,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6833,6 +6845,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.3.7",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
Closes #72.

## Summary

- **Fix DnD into-folder reliability** — When the drag source is a session, the entire folder row is now the `into-folder` hit zone. Previously the row used a 25 / 50 / 25 split (above / into / below), which on a 28px row left only ~14px of "into" target — drops near the top or bottom of a folder landed *next to* the folder instead of *inside* it. This is what users were reporting in #72 as "unable to drag and drop a connection into a folder." Folder-on-folder still uses the split so folders can be reordered.
- **Right-click on a session → "Move to folder…"** opens a tree-picker modal (incl. `(Root)`) and calls `session_move`.
- **Right-click on a folder → "Move to folder…" / "Sort A → Z" / "Sort Z → A"** with cycle protection on move (a folder cannot move into itself or any descendant). Sort acts on the folder's *immediate* children only — folders and sessions are sorted independently, folders rendered above sessions per the existing tree layout. Sort is also exposed on the empty-area (root) right-click menu.
- New `MoveToFolderDialog` component matching the existing `prompt-dialog` pattern.

Backend was already complete: `session_move`, `session_reorder`, `folder_move`, `folder_reorder` — this PR is frontend-only.

## Test plan

- [ ] Drag a session onto the **top edge** of a folder — lands inside (was: landed above)
- [ ] Drag a session onto the **bottom edge** of a folder — lands inside (was: landed below)
- [ ] Drag a folder onto another folder's top/middle/bottom thirds — reorders / nests / reorders (unchanged)
- [ ] Right-click a session → **Move to folder…** → pick `(Root)` and a folder; "current" is disabled
- [ ] Right-click a folder → **Move to folder…** → confirm self + all descendants are disabled
- [ ] Right-click a folder with mixed children → **Sort A → Z** then **Sort Z → A**; folders + sessions sort independently, folders stay above sessions
- [ ] Right-click empty area → **Sort** sorts root children
- [ ] `cargo check` clean (the one pre-existing `VCXSRV_INSTALLER_URL` warning is unrelated)
- [ ] `npm run lint` clean (no new warnings)
- [ ] `npm run typecheck` clean