### PR TITLE
fix(terminal): foreground window + focus xterm on right-click paste (#74)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "argon2",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.3.7"
+version = "1.3.8"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/ui/components/terminal.tsx
+++ b/ui/components/terminal.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AlertCircle, Loader2, PlugZap } from 'lucide-react';
 import { readText, writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { api, errMessage } from '@/lib/tauri';
 import { createTerminal, type TerminalBundle } from '@/lib/xterm';
 import { subscribeSshEvents } from '@/lib/ssh';
@@ -347,6 +348,11 @@ export function TerminalView({ tab, visible }: Props) {
 
   function handleContextMenu(e: React.MouseEvent) {
     e.preventDefault();
+    // If the user right-clicks while ezTerm is in the background (common when
+    // copying from another app and pasting here), pull the window forward so
+    // the subsequent action — and any keystrokes after it — land in the
+    // terminal without an extra left-click.
+    getCurrentWindow().setFocus().catch(() => {});
     setMenu({ x: e.clientX, y: e.clientY });
   }
 
@@ -443,6 +449,12 @@ export function TerminalView({ tab, visible }: Props) {
     if (!txt || !tab.connectionId) return;
     const bytes = new TextEncoder().encode(txt);
     await termApiRef.current.write(tab.connectionId, Array.from(bytes)).catch(() => {});
+    // Ensure the window is foregrounded and xterm has focus so the user can
+    // keep typing immediately after pasting — otherwise right-click → Paste
+    // from a background ezTerm requires an extra left-click before keys go
+    // through.
+    getCurrentWindow().setFocus().catch(() => {});
+    bundleRef.current?.terminal.focus();
   }
 
   const showOverlay = tab.status !== 'connected' && !prompt && !authFix && !xserverMissing;


### PR DESCRIPTION
## Summary
- Right-click on the terminal now calls `getCurrentWindow().setFocus()` so ezTerm comes to the foreground when the context menu opens.
- `doPaste()` also calls `setFocus()` and re-focuses the xterm instance after writing pasted bytes, so the user can keep typing immediately — no extra left-click needed.

Closes #74.

## Test plan
- [ ] Switch focus to another app, copy text, right-click ezTerm terminal → window comes forward.
- [ ] Click **Paste** → text appears in the terminal and subsequent keystrokes go to the shell with no left-click.
- [ ] Shift+Insert and Ctrl+Shift+V paste paths still work when ezTerm is already focused.
- [ ] `cargo check` clean (warnings unchanged); `npm run lint` clean (warnings unchanged).