### PR TITLE
feat(sftp): per-folder + directory uploads + Windows drag-out scaffold (#28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
  "zeroize",
 ]
 
@@ -7237,8 +7239,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7327,6 +7329,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7370,12 +7382,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -7387,8 +7412,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -7418,9 +7443,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7472,6 +7519,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -7486,6 +7542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/docs/release-notes/v1.5.0.md
+++ b/docs/release-notes/v1.5.0.md
@@ -1,0 +1,39 @@
+# ezTerm v1.5.0
+
+Minor: SFTP drag-and-drop. First slice of issue #28 — per-folder drop targets, full directory uploads, in-pane progress for tree uploads, and the Windows OLE drag-source scaffold for drag-out (validated via `__ezterm.dragTestFile` from devtools; SFTP integration arrives in v1.6.0 / phase B2).
+
+## Drag-in (uploads)
+
+- **`ui/components/sftp-file-row.tsx`** — Each folder row is now a drop target. Drop OS files onto a folder and they upload INTO it instead of landing in the current `cwd`. The row highlights with the accent colour while a drag is over it. Non-folder rows still pass the drag through to the pane-wide handler.
+- **`ui/components/sftp-pane.tsx`** — Refactored the drop handler into a shared `uploadDataTransfer(targetDir, dt)` so per-folder and pane-wide drops share the same code path. Directory uploads via `webkitGetAsEntry()` walk the dropped tree, `sftpMkdir` each remote folder (errors swallowed so re-uploads work over existing trees), and ship each leaf file through `sftp_upload_bytes` with the existing 256 MB per-file cap. A `DirectoryJobs` strip above the per-file `TransferStatus` shows a live `N / M` count while the walk runs, then a one-line summary the user can dismiss.
+
+## Drag-out scaffold (Windows)
+
+- **`src-tauri/src/sftp/drag/`** (new module) — Cross-platform dispatcher (`mod.rs`) with a Windows-only OLE implementation in `win.rs`. Implements `IDataObject` exposing `CFSTR_FILEDESCRIPTORW` + `CFSTR_FILECONTENTS`, an `IEnumFORMATETC`, an `IDropSource` handling escape/release, and a `MemoryStream` (`IStream`) backed by `Vec<u8>`. The dedicated drag thread runs `OleInitialize(COINIT_APARTMENTTHREADED)` and calls `DoDragDrop`, blocking until the user drops or cancels. Non-Windows platforms surface a clear "unsupported" error pending phases B5 (macOS `NSFilePromiseProvider`) and B6 (Linux XDS / Wayland).
+- **`src-tauri/src/commands/sftp.rs`** — New `drag_test_file(name, body)` Tauri command. Runs the drag on `tokio::task::spawn_blocking` so the message loop pump doesn't starve the runtime. Returns `'dropped'` or `'cancelled'`.
+- **`ui/lib/tauri.ts`** — `api.dragTestFile` wrapper plus `exposeDevApi()` that pins `api` to `window.__ezterm` when `NODE_ENV !== 'production'` (or `localStorage.ezterm_dev === '1'`). Validate the drag end-to-end from devtools:
+  ```js
+  await window.__ezterm.dragTestFile('hello.txt', 'hi from ezTerm');
+  // then drag from the cursor onto Explorer
+  ```
+
+## What's deferred
+
+- **Phase B2** (SFTP integration with pre-buffered downloads up to 256 MB) — next PR.
+- **Phase B3** (streaming `IStream` for arbitrary sizes), **B4** (multi-file / directory drag-out), **B5** (macOS), **B6** (Linux), **B7** (polish) — see issue #28 for the roadmap.
+- **A3** (streaming uploads to lift the 256 MB cap) — bundled with B3 in a later PR.
+
+## Build / dev notes
+
+- Added `windows` crate (`0.58`, features `implement`, `Win32_Graphics_Gdi`, `Win32_System_Ole`, `Win32_System_Com`, `Win32_System_Com_StructuredStorage`, `Win32_UI_Shell`, …) as a `[target.'cfg(windows)'.dependencies]` entry — no impact on Linux/macOS builds.
+- Cross-compile verified via `cargo check --target x86_64-pc-windows-gnu` against mingw.
+
+## Verify
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Licence
+
+**GPL v3** (version 3 only). See [LICENSE](../blob/main/LICENSE).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,32 @@ rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustl
 # TLS stack (no OpenSSL dep).
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
+# Native OLE drag source for SFTP drag-out. Windows-only dep — the
+# webview can't supply real OS-visible files to Explorer / file
+# managers, so we implement IDataObject + IDropSource ourselves and
+# stream bytes via IStream. macOS and Linux equivalents (NSFilePromise,
+# XDS, wl_data_source) are deferred to phases B5/B6 of issue #28.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "implement",
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Ole",
+    "Win32_System_Memory",
+    "Win32_System_DataExchange",
+    "Win32_System_SystemServices",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Input_KeyboardAndMouse",
+] }
+# windows-implement / windows-interface generate code that references the
+# `windows_core` crate by name (not via windows::core). Pull it in
+# directly so the #[implement] macro on our IDataObject etc. resolves.
+windows-core = "0.58"
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -346,3 +346,32 @@ pub async fn sftp_download(
     });
     Ok(TransferTicket { transfer_id })
 }
+
+/// Test command for phase B1 of issue #28 — spawns an OS-native drag
+/// source carrying a hardcoded `body` as a single virtual file named
+/// `name`. Returns whether the user dropped or cancelled. Wired up to
+/// validate the COM plumbing end-to-end without needing an SFTP
+/// session: a dev can call this from the browser console (or a
+/// future test menu) and confirm that dropping into Explorer creates
+/// a real file with the expected bytes.
+///
+/// Windows-only today; non-Windows platforms surface a clear
+/// "unsupported" error from `sftp::drag::start_file_drag`.
+#[tauri::command]
+pub async fn drag_test_file(
+    state: State<'_, AppState>,
+    name: String,
+    body: String,
+) -> Result<crate::sftp::drag::DragOutcome> {
+    super::require_unlocked(&state).await?;
+    // DoDragDrop blocks the calling thread — we MUST move it off the
+    // tokio worker pool. `spawn_blocking` does exactly that and joins
+    // the synchronous return back into the async command.
+    let bytes = body.into_bytes();
+    let outcome = tokio::task::spawn_blocking(move || {
+        crate::sftp::drag::start_file_drag(name, bytes)
+    })
+    .await
+    .map_err(|e| AppError::Validation(format!("drag task panicked: {e}")))??;
+    Ok(outcome)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,6 +93,7 @@ async fn main() {
             commands::sftp::sftp_upload,
             commands::sftp::sftp_upload_bytes,
             commands::sftp::sftp_download,
+            commands::sftp::drag_test_file,
             commands::scp::scp_upload,
             commands::scp::scp_download,
             commands::local::local_connect,

--- a/src-tauri/src/sftp/drag/mod.rs
+++ b/src-tauri/src/sftp/drag/mod.rs
@@ -1,0 +1,81 @@
+//! Native OS drag source for SFTP drag-out. The webview can't supply
+//! Explorer / Finder / file managers with a real path to a remote file,
+//! so we implement the OS-native drag protocols ourselves and stream
+//! bytes on demand:
+//!
+//! - **Windows**: OLE drag with [`IDataObject`] exposing
+//!   `CFSTR_FILEDESCRIPTORW` + `CFSTR_FILECONTENTS`. The actual byte
+//!   stream is wrapped in an [`IStream`]. See `win.rs`.
+//! - **macOS**: `NSFilePromiseProvider` + delegate (phase B5 of #28 —
+//!   not yet implemented).
+//! - **Linux**: XDS (X11) and `wl_data_source` (Wayland) (phase B6 of
+//!   #28 — not yet implemented).
+//!
+//! This module is the cross-platform entry point. On unsupported
+//! platforms every entry point returns an `Unsupported` error so the
+//! rest of the app builds and runs without a `#[cfg]` cascade at every
+//! call site.
+
+#[cfg_attr(windows, allow(unused_imports))]
+use crate::error::{AppError, Result};
+
+#[cfg(windows)]
+pub mod win;
+
+/// Start an OS-native drag of `name`'s content payload. Blocks the
+/// current thread until the user drops (or cancels). Spawning a
+/// dedicated thread is the caller's responsibility — `DoDragDrop`
+/// pumps the message loop, which we don't want to do from a tokio
+/// worker.
+///
+/// Phase B1 of issue #28: in-memory `Vec<u8>` only, no streaming yet.
+/// Phase B3 will replace the payload with a streaming `IStream`
+/// backed by SFTP reads.
+#[allow(dead_code)] // wired by drag_test_file; full SFTP integration arrives in B2.
+pub fn start_file_drag(name: String, bytes: Vec<u8>) -> Result<DragOutcome> {
+    #[cfg(windows)]
+    {
+        win::start_file_drag(name, bytes)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (name, bytes);
+        Err(AppError::Validation(
+            "drag-out is not yet implemented on this platform (see issue #28 phases B5/B6)".into(),
+        ))
+    }
+}
+
+/// What the OS reported when the drag finished. The caller can use
+/// this to decide whether to refresh the SFTP listing (drop happened)
+/// or just unwind silently (user cancelled).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // exposed via drag_test_file return; consumer arrives with B2.
+pub enum DragOutcome {
+    /// User dropped the file onto a valid target.
+    Dropped,
+    /// User cancelled (Escape, or released over a non-target).
+    Cancelled,
+}
+
+#[cfg(not(windows))]
+impl From<()> for DragOutcome {
+    fn from(_: ()) -> Self { DragOutcome::Cancelled }
+}
+
+/// Convenience for the test command: a wrapper that surfaces an error
+/// uniformly on all platforms.
+#[allow(dead_code)]
+pub fn ensure_supported() -> Result<()> {
+    #[cfg(windows)]
+    {
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        Err(AppError::Validation(
+            "drag-out is currently Windows-only; macOS and Linux land in phases B5/B6 of issue #28".into(),
+        ))
+    }
+}

--- a/src-tauri/src/sftp/drag/win.rs
+++ b/src-tauri/src/sftp/drag/win.rs
@@ -1,0 +1,449 @@
+//! Windows OLE drag-source implementation. Hand-rolled IDataObject +
+//! IDropSource + IEnumFORMATETC + IStream so Explorer / 7-Zip / Total
+//! Commander can pull a "virtual file" out of ezTerm.
+//!
+//! The story end-to-end:
+//! 1. The caller spawns a dedicated `std::thread` (the OS message loop
+//!    `DoDragDrop` pumps internally is not tokio-compatible — we never
+//!    call this from a tokio worker).
+//! 2. We `OleInitialize` (APARTMENTTHREADED) on that thread.
+//! 3. We construct `FileDescriptorData` (our `IDataObject`) holding
+//!    one filename + one byte payload, and `DragSource` (our
+//!    `IDropSource`) tracking the mouse state.
+//! 4. We call `DoDragDrop`. It blocks. Explorer calls our
+//!    `GetData(CFSTR_FILEDESCRIPTORW)` to learn the filename; on drop
+//!    it calls `GetData(CFSTR_FILECONTENTS, lindex=0)` and reads bytes
+//!    from the returned `IStream`.
+//! 5. `DoDragDrop` returns `DRAGDROP_S_DROP` (the user dropped) or
+//!    `DRAGDROP_S_CANCEL` (Escape / dropped on void). We translate
+//!    both to [`super::DragOutcome`].
+//!
+//! Phase B1 hard-codes the payload as a `Vec<u8>`. Phase B3 will swap
+//! the `MemoryStream` for an `SftpStream` that pulls bytes from a
+//! background tokio task via a bounded channel; the IDataObject and
+//! IDropSource code below doesn't change.
+
+use std::ffi::OsStr;
+use std::mem::ManuallyDrop;
+use std::os::windows::ffi::OsStrExt;
+use std::sync::Mutex;
+
+use windows::core::{implement, Result as WinResult, PCWSTR};
+use windows::Win32::Foundation::{
+    BOOL, DATA_S_SAMEFORMATETC, DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS,
+    DV_E_FORMATETC, DV_E_TYMED, E_NOTIMPL, HGLOBAL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
+};
+use windows::Win32::System::Com::{
+    IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumFORMATETC_Impl,
+    IEnumSTATDATA, ISequentialStream_Impl, IStream, IStream_Impl, FORMATETC, LOCKTYPE, STATFLAG,
+    STATSTG, STGC, STGMEDIUM, STGMEDIUM_0, STGTY_STREAM, STREAM_SEEK, STREAM_SEEK_CUR,
+    STREAM_SEEK_END, STREAM_SEEK_SET, TYMED_HGLOBAL, TYMED_ISTREAM,
+};
+use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
+use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+use windows::Win32::System::Ole::{
+    DoDragDrop, IDropSource, IDropSource_Impl, OleInitialize, OleUninitialize,
+    DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
+};
+use windows::Win32::System::SystemServices::MODIFIERKEYS_FLAGS;
+use windows::Win32::UI::Shell::{FD_FILESIZE, FD_PROGRESSUI, FILEDESCRIPTORW, FILEGROUPDESCRIPTORW};
+
+use crate::error::{AppError, Result};
+
+use super::DragOutcome;
+
+// ===== shell clipboard format registration ================================
+
+/// `CFSTR_FILEDESCRIPTORW` / `CFSTR_FILECONTENTS` are registered at
+/// runtime by the shell; the integers come back stable for the
+/// process lifetime. We register them lazily and cache.
+fn registered_format(name: &[u16]) -> u16 {
+    // SAFETY: name is a valid null-terminated UTF-16 buffer.
+    let id = unsafe { RegisterClipboardFormatW(PCWSTR(name.as_ptr())) };
+    id as u16
+}
+
+fn wide(s: &str) -> Vec<u16> {
+    OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
+}
+
+fn cf_file_descriptor() -> u16 {
+    static W: std::sync::OnceLock<Vec<u16>> = std::sync::OnceLock::new();
+    registered_format(W.get_or_init(|| wide("FileGroupDescriptorW")))
+}
+
+fn cf_file_contents() -> u16 {
+    static W: std::sync::OnceLock<Vec<u16>> = std::sync::OnceLock::new();
+    registered_format(W.get_or_init(|| wide("FileContents")))
+}
+
+// ===== IStream backed by an in-memory Vec<u8> =============================
+
+#[implement(IStream)]
+struct MemoryStream {
+    inner: Mutex<MemoryStreamState>,
+}
+
+struct MemoryStreamState {
+    bytes: Vec<u8>,
+    pos:   u64,
+}
+
+impl MemoryStream {
+    fn new(bytes: Vec<u8>) -> IStream {
+        let me = MemoryStream { inner: Mutex::new(MemoryStreamState { bytes, pos: 0 }) };
+        me.into()
+    }
+}
+
+#[allow(non_snake_case)]
+impl ISequentialStream_Impl for MemoryStream_Impl {
+    fn Read(&self, pv: *mut std::ffi::c_void, cb: u32, pcb_read: *mut u32) -> windows::core::HRESULT {
+        let mut g = self.inner.lock().unwrap();
+        let len = g.bytes.len() as u64;
+        let remaining = len.saturating_sub(g.pos);
+        let n = (cb as u64).min(remaining) as usize;
+        if n > 0 {
+            let start = g.pos as usize;
+            // SAFETY: caller guarantees pv points to cb bytes of writable memory.
+            unsafe {
+                std::ptr::copy_nonoverlapping(g.bytes[start..start + n].as_ptr(), pv as *mut u8, n);
+            }
+            g.pos += n as u64;
+        }
+        if !pcb_read.is_null() {
+            // SAFETY: caller passes a valid u32 out-pointer (or NULL).
+            unsafe { *pcb_read = n as u32; }
+        }
+        S_OK
+    }
+
+    fn Write(&self, _pv: *const std::ffi::c_void, _cb: u32, _pcb_written: *mut u32) -> windows::core::HRESULT {
+        // Drag-out streams are read-only as far as the OS shell is
+        // concerned. E_NOTIMPL is what most reference implementations
+        // return for an out-stream that doesn't take writes.
+        E_NOTIMPL
+    }
+}
+
+#[allow(non_snake_case)]
+impl IStream_Impl for MemoryStream_Impl {
+    fn Seek(&self, dlibmove: i64, dworigin: STREAM_SEEK, plibnewposition: *mut u64) -> WinResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        let base = match dworigin {
+            STREAM_SEEK_SET => 0i64,
+            STREAM_SEEK_CUR => g.pos as i64,
+            STREAM_SEEK_END => g.bytes.len() as i64,
+            _ => return Err(E_NOTIMPL.into()),
+        };
+        let new_pos = base.saturating_add(dlibmove).max(0) as u64;
+        g.pos = new_pos;
+        if !plibnewposition.is_null() {
+            // SAFETY: caller passes a valid u64 out-pointer (or NULL).
+            unsafe { *plibnewposition = new_pos; }
+        }
+        Ok(())
+    }
+
+    fn SetSize(&self, _libnewsize: u64) -> WinResult<()> { Err(E_NOTIMPL.into()) }
+    fn CopyTo(&self, _stm: Option<&IStream>, _cb: u64, _pcb_read: *mut u64, _pcb_written: *mut u64) -> WinResult<()> {
+        Err(E_NOTIMPL.into())
+    }
+    fn Commit(&self, _grfcommitflags: &STGC) -> WinResult<()> { Ok(()) }
+    fn Revert(&self) -> WinResult<()> { Ok(()) }
+    fn LockRegion(&self, _liboffset: u64, _cb: u64, _dwlocktype: &LOCKTYPE) -> WinResult<()> {
+        Err(E_NOTIMPL.into())
+    }
+    fn UnlockRegion(&self, _liboffset: u64, _cb: u64, _dwlocktype: u32) -> WinResult<()> {
+        Err(E_NOTIMPL.into())
+    }
+    fn Stat(&self, pstatstg: *mut STATSTG, _grfstatflag: &STATFLAG) -> WinResult<()> {
+        if pstatstg.is_null() { return Err(E_NOTIMPL.into()); }
+        let g = self.inner.lock().unwrap();
+        let mut s: STATSTG = unsafe { std::mem::zeroed() };
+        s.cbSize = g.bytes.len() as u64;
+        s.r#type = STGTY_STREAM.0 as u32;
+        // SAFETY: caller passes a valid STATSTG out-pointer.
+        unsafe { *pstatstg = s; }
+        Ok(())
+    }
+    fn Clone(&self) -> WinResult<IStream> { Err(E_NOTIMPL.into()) }
+}
+
+// ===== IDataObject implementation =========================================
+
+#[implement(IDataObject)]
+struct FileDescriptorData {
+    name:  Vec<u16>, // wide, null-terminated
+    bytes: Mutex<Option<Vec<u8>>>,
+    cf_descriptor: u16,
+    cf_contents:   u16,
+}
+
+impl FileDescriptorData {
+    fn new(name: &str, bytes: Vec<u8>) -> IDataObject {
+        let me = FileDescriptorData {
+            name:  wide(name),
+            bytes: Mutex::new(Some(bytes)),
+            cf_descriptor: cf_file_descriptor(),
+            cf_contents:   cf_file_contents(),
+        };
+        me.into()
+    }
+
+    /// Build the FILEGROUPDESCRIPTORW HGLOBAL for our single file.
+    fn build_descriptor_hglobal(&self) -> WinResult<HGLOBAL> {
+        // FILEGROUPDESCRIPTORW already inlines one FILEDESCRIPTORW
+        // (cItems = 1, fgd[0]). Phase B4 will grow this to N descriptors
+        // (size = sizeof(FILEGROUPDESCRIPTORW) + (N - 1) * sizeof(FD)).
+        let size = std::mem::size_of::<FILEGROUPDESCRIPTORW>();
+        // SAFETY: GMEM_MOVEABLE is the canonical flag for HGLOBALs that
+        // travel via OLE. GlobalAlloc returns Err on failure.
+        let hg = unsafe { GlobalAlloc(GMEM_MOVEABLE, size)? };
+        // SAFETY: GlobalLock on a fresh HGLOBAL returns a valid pointer
+        // to at least `size` bytes; we zero them, then fill the header
+        // and one descriptor.
+        unsafe {
+            let p = GlobalLock(hg);
+            if p.is_null() {
+                return Err(E_NOTIMPL.into());
+            }
+            std::ptr::write_bytes(p as *mut u8, 0, size);
+            let header = p as *mut FILEGROUPDESCRIPTORW;
+            (*header).cItems = 1;
+            let desc = std::ptr::addr_of_mut!((*header).fgd) as *mut FILEDESCRIPTORW;
+            let bytes_len = self
+                .bytes
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|b| b.len() as u64)
+                .unwrap_or(0);
+            (*desc).dwFlags = (FD_FILESIZE.0 | FD_PROGRESSUI.0) as u32;
+            (*desc).nFileSizeLow  = (bytes_len & 0xFFFF_FFFF) as u32;
+            (*desc).nFileSizeHigh = (bytes_len >> 32) as u32;
+            // FILEDESCRIPTORW is packed, so taking a Rust reference to
+            // its inner cFileName array is UB even before deref. Get
+            // a raw pointer to the array and copy via that.
+            let cfilename_ptr = std::ptr::addr_of_mut!((*desc).cFileName) as *mut u16;
+            let copy_len = self.name.len().min(260);
+            std::ptr::copy_nonoverlapping(
+                self.name.as_ptr(),
+                cfilename_ptr,
+                copy_len,
+            );
+            let _ = GlobalUnlock(hg);
+        }
+        Ok(hg)
+    }
+}
+
+#[allow(non_snake_case)]
+impl IDataObject_Impl for FileDescriptorData_Impl {
+    fn GetData(&self, pformatetcin: *const FORMATETC) -> WinResult<STGMEDIUM> {
+        if pformatetcin.is_null() {
+            return Err(DV_E_FORMATETC.into());
+        }
+        // SAFETY: caller guarantees pformatetcin points to a valid
+        // FORMATETC for the duration of the call.
+        let fe = unsafe { &*pformatetcin };
+        if fe.cfFormat == self.cf_descriptor && fe.tymed & TYMED_HGLOBAL.0 as u32 != 0 {
+            let hg = self.build_descriptor_hglobal()?;
+            let mut m = STGMEDIUM::default();
+            m.tymed = TYMED_HGLOBAL.0 as u32;
+            m.u = STGMEDIUM_0 { hGlobal: hg };
+            return Ok(m);
+        }
+        if fe.cfFormat == self.cf_contents && fe.tymed & TYMED_ISTREAM.0 as u32 != 0 {
+            // lindex tells us which file's contents to return (we
+            // only have one). Anything other than 0 / -1 is an error.
+            if fe.lindex > 0 {
+                return Err(DV_E_FORMATETC.into());
+            }
+            let bytes = self.bytes.lock().unwrap().take().unwrap_or_default();
+            let stream = MemoryStream::new(bytes);
+            let mut m = STGMEDIUM::default();
+            m.tymed = TYMED_ISTREAM.0 as u32;
+            m.u = STGMEDIUM_0 { pstm: ManuallyDrop::new(Some(stream)) };
+            return Ok(m);
+        }
+        Err(DV_E_FORMATETC.into())
+    }
+
+    fn GetDataHere(&self, _pformatetc: *const FORMATETC, _pmedium: *mut STGMEDIUM) -> WinResult<()> {
+        Err(E_NOTIMPL.into())
+    }
+
+    fn QueryGetData(&self, pformatetc: *const FORMATETC) -> windows::core::HRESULT {
+        if pformatetc.is_null() { return DV_E_FORMATETC; }
+        let fe = unsafe { &*pformatetc };
+        if fe.cfFormat == self.cf_descriptor && fe.tymed & TYMED_HGLOBAL.0 as u32 != 0 { return S_OK; }
+        if fe.cfFormat == self.cf_contents && fe.tymed & TYMED_ISTREAM.0 as u32 != 0 { return S_OK; }
+        if fe.cfFormat == self.cf_descriptor || fe.cfFormat == self.cf_contents {
+            return DV_E_TYMED;
+        }
+        DV_E_FORMATETC
+    }
+
+    fn GetCanonicalFormatEtc(
+        &self,
+        _pformatect_in: *const FORMATETC,
+        pformatetc_out: *mut FORMATETC,
+    ) -> windows::core::HRESULT {
+        if !pformatetc_out.is_null() {
+            unsafe { (*pformatetc_out).ptd = std::ptr::null_mut(); }
+        }
+        DATA_S_SAMEFORMATETC
+    }
+
+    fn SetData(&self, _pformatetc: *const FORMATETC, _pmedium: *const STGMEDIUM, _frelease: BOOL) -> WinResult<()> {
+        Err(E_NOTIMPL.into())
+    }
+
+    fn EnumFormatEtc(&self, dwdirection: u32) -> WinResult<IEnumFORMATETC> {
+        // DATADIR_GET = 1
+        if dwdirection != 1 {
+            return Err(E_NOTIMPL.into());
+        }
+        let fmts = vec![
+            FORMATETC {
+                cfFormat: self.cf_descriptor,
+                ptd: std::ptr::null_mut(),
+                dwAspect: 1, // DVASPECT_CONTENT
+                lindex: -1,
+                tymed: TYMED_HGLOBAL.0 as u32,
+            },
+            FORMATETC {
+                cfFormat: self.cf_contents,
+                ptd: std::ptr::null_mut(),
+                dwAspect: 1,
+                lindex: 0,
+                tymed: TYMED_ISTREAM.0 as u32,
+            },
+        ];
+        Ok(FormatEnumerator { fmts, idx: Mutex::new(0) }.into())
+    }
+
+    fn DAdvise(&self, _pformatetc: *const FORMATETC, _advf: u32, _padv_sink: Option<&IAdviseSink>) -> WinResult<u32> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+    fn DUnadvise(&self, _dw_connection: u32) -> WinResult<()> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+    fn EnumDAdvise(&self) -> WinResult<IEnumSTATDATA> {
+        Err(OLE_E_ADVISENOTSUPPORTED.into())
+    }
+}
+
+// ===== IEnumFORMATETC implementation ======================================
+
+#[implement(IEnumFORMATETC)]
+struct FormatEnumerator {
+    fmts: Vec<FORMATETC>,
+    idx:  Mutex<usize>,
+}
+
+#[allow(non_snake_case)]
+impl IEnumFORMATETC_Impl for FormatEnumerator_Impl {
+    fn Next(&self, celt: u32, rgelt: *mut FORMATETC, pcelt_fetched: *mut u32) -> windows::core::HRESULT {
+        let mut idx = self.idx.lock().unwrap();
+        let mut n = 0usize;
+        while n < celt as usize && *idx < self.fmts.len() {
+            // SAFETY: caller guarantees rgelt has space for celt entries.
+            unsafe { *rgelt.add(n) = self.fmts[*idx]; }
+            *idx += 1;
+            n += 1;
+        }
+        if !pcelt_fetched.is_null() {
+            unsafe { *pcelt_fetched = n as u32; }
+        }
+        if n == celt as usize { S_OK } else { S_FALSE }
+    }
+
+    fn Skip(&self, celt: u32) -> WinResult<()> {
+        let mut idx = self.idx.lock().unwrap();
+        let new = *idx + celt as usize;
+        if new > self.fmts.len() {
+            *idx = self.fmts.len();
+            Err(S_FALSE.into())
+        } else {
+            *idx = new;
+            Ok(())
+        }
+    }
+
+    fn Reset(&self) -> WinResult<()> {
+        *self.idx.lock().unwrap() = 0;
+        Ok(())
+    }
+
+    fn Clone(&self) -> WinResult<IEnumFORMATETC> {
+        Ok(FormatEnumerator {
+            fmts: self.fmts.clone(),
+            idx:  Mutex::new(*self.idx.lock().unwrap()),
+        }.into())
+    }
+}
+
+// ===== IDropSource implementation =========================================
+
+#[implement(IDropSource)]
+struct DragSource;
+
+#[allow(non_snake_case)]
+impl IDropSource_Impl for DragSource_Impl {
+    fn QueryContinueDrag(&self, fescape_pressed: BOOL, grfkeystate: MODIFIERKEYS_FLAGS) -> windows::core::HRESULT {
+        // Standard OLE drag semantics:
+        //   - Escape ⇒ DRAGDROP_S_CANCEL
+        //   - Left button released ⇒ DRAGDROP_S_DROP
+        //   - otherwise S_OK (keep dragging)
+        const MK_LBUTTON: u32 = 0x0001;
+        if fescape_pressed.as_bool() {
+            return DRAGDROP_S_CANCEL;
+        }
+        if grfkeystate.0 & MK_LBUTTON == 0 {
+            return DRAGDROP_S_DROP;
+        }
+        S_OK
+    }
+
+    fn GiveFeedback(&self, _dweffect: DROPEFFECT) -> windows::core::HRESULT {
+        // Let the OS pick the cursor based on the drop target's accepted
+        // effect. We'll customise this in phase B7 to show a download
+        // arrow + progress.
+        DRAGDROP_S_USEDEFAULTCURSORS
+    }
+}
+
+// ===== entry point ========================================================
+
+/// Spawn a dedicated thread, OleInitialize it, and call DoDragDrop
+/// with our IDataObject + IDropSource. Blocks until the drag finishes.
+/// Returns whether the user dropped or cancelled.
+pub fn start_file_drag(name: String, bytes: Vec<u8>) -> Result<DragOutcome> {
+    let handle = std::thread::spawn(move || -> Result<DragOutcome> {
+        // SAFETY: We exclusively own this thread; OleInitialize is the
+        // documented entry for COM apartment-threaded use, and
+        // OleUninitialize on the same thread balances it.
+        unsafe {
+            OleInitialize(None)
+                .map_err(|e| AppError::Validation(format!("OleInitialize: {e:?}")))?;
+        }
+
+        let data: IDataObject = FileDescriptorData::new(&name, bytes);
+        let source: IDropSource = DragSource.into();
+        let mut effect = DROPEFFECT_NONE;
+
+        let hr = unsafe { DoDragDrop(&data, &source, DROPEFFECT_COPY, &mut effect) };
+
+        unsafe { OleUninitialize(); }
+
+        match hr {
+            DRAGDROP_S_DROP => Ok(DragOutcome::Dropped),
+            DRAGDROP_S_CANCEL => Ok(DragOutcome::Cancelled),
+            other => Err(AppError::Validation(format!("DoDragDrop returned 0x{:08x}", other.0))),
+        }
+    });
+
+    handle.join().map_err(|_| AppError::Validation("drag thread panicked".into()))?
+}

--- a/src-tauri/src/sftp/mod.rs
+++ b/src-tauri/src/sftp/mod.rs
@@ -1,3 +1,4 @@
+pub mod drag;
 pub mod registry;
 pub mod session;
 pub mod transfer;

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { api } from '@/lib/tauri';
+import { api, exposeDevApi } from '@/lib/tauri';
 import type { VaultStatus } from '@/lib/types';
 import { applyTheme, loadTheme } from '@/lib/theme';
 import { UnlockScreen } from '@/components/unlock-screen';
@@ -11,6 +11,7 @@ export default function Page() {
   const [status, setStatus] = useState<VaultStatus | null>(null);
 
   useEffect(() => {
+    exposeDevApi();
     (async () => {
       applyTheme(await loadTheme());
       setStatus(await api.vaultStatus());

--- a/ui/components/sftp-file-row.tsx
+++ b/ui/components/sftp-file-row.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import { File, FileSymlink, Folder } from 'lucide-react';
 import type { SftpEntry } from '@/lib/types';
 
@@ -6,6 +7,10 @@ interface Props {
   entry: SftpEntry;
   onOpen:    (e: SftpEntry) => void;
   onContext: (e: SftpEntry, cx: number, cy: number) => void;
+  /** Drop handler when this row is a folder. The caller routes the OS
+   *  drop into a per-folder upload. Called with the row's full path.
+   *  Undefined for non-folder rows. */
+  onFolderDrop?: (entry: SftpEntry, ev: React.DragEvent) => void;
 }
 
 function formatSize(bytes: number): string {
@@ -28,20 +33,42 @@ function formatMode(mode: number): string {
   return out;
 }
 
-export function SftpFileRow({ entry, onOpen, onContext }: Props) {
-  // Icon + color vary by entry type. Dirs use the accent so the eye catches
-  // the only thing the user can navigate into.
+export function SftpFileRow({ entry, onOpen, onContext, onFolderDrop }: Props) {
+  const [dragOver, setDragOver] = useState(false);
+
   let Icon = File;
   let iconCls = 'text-muted';
   if (entry.is_dir) { Icon = Folder; iconCls = 'text-accent'; }
   else if (entry.is_symlink) { Icon = FileSymlink; iconCls = 'text-warning'; }
+
+  // Per-folder drop wiring. We stop propagation so the pane-wide
+  // handler in SftpPane doesn't ALSO see the drop and double-upload.
+  // Files-only rows ignore drag events entirely so the OS keeps
+  // showing the "no-drop" cursor over them.
+  const folderDnD = entry.is_dir && onFolderDrop ? {
+    onDragOver: (ev: React.DragEvent) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (!dragOver) setDragOver(true);
+    },
+    onDragLeave: () => setDragOver(false),
+    onDrop: (ev: React.DragEvent) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      setDragOver(false);
+      onFolderDrop(entry, ev);
+    },
+  } : {};
 
   return (
     <div
       role="row"
       onDoubleClick={() => onOpen(entry)}
       onContextMenu={(e) => { e.preventDefault(); onContext(entry, e.clientX, e.clientY); }}
-      className="grid grid-cols-[1fr_70px_72px] gap-2 px-2 h-6 items-center text-xs hover:bg-surface2/60 cursor-default select-none"
+      {...folderDnD}
+      className={`grid grid-cols-[1fr_70px_72px] gap-2 px-2 h-6 items-center text-xs cursor-default select-none ${
+        dragOver ? 'bg-accent/20 ring-1 ring-accent ring-inset' : 'hover:bg-surface2/60'
+      }`}
     >
       <span className="truncate flex items-center gap-1.5 min-w-0">
         <Icon size={13} className={`${iconCls} shrink-0`} />

--- a/ui/components/sftp-pane.tsx
+++ b/ui/components/sftp-pane.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FolderPlus, Inbox, Loader2, RefreshCw, Upload, UploadCloud } from 'lucide-react';
 import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog';
 import { api, errMessage } from '@/lib/tauri';
@@ -13,6 +13,53 @@ import { TransferStatus, type TrackedTransfer } from './transfer-status';
 import { ConfirmDialog } from './confirm-dialog';
 import { PromptDialog } from './prompt-dialog';
 import { EmptyState } from './empty-state';
+
+const UPLOAD_CAP_BYTES = 256 * 1024 * 1024;
+
+/** Tracks an in-progress directory upload (one job per dropped tree).
+ *  Files inside the tree still surface as individual transfers via the
+ *  existing TransferStatus strip; this job tracks the parent walk so
+ *  the user sees "uploading directory X (12/87 files)" while we mkdir
+ *  and enqueue each leaf. */
+interface DirJob {
+  id: number;
+  rootName: string;
+  total: number;
+  done: number;
+  failed: number;
+  finished: boolean;
+}
+
+/** Pluck the FileSystemEntry off a DataTransferItem — supports both
+ *  the modern `getAsEntry()` (TC39 file-system access) and the legacy
+ *  `webkitGetAsEntry()` that Chromium-based webviews still expose. */
+function entryFromItem(item: DataTransferItem): FileSystemEntry | null {
+  // Modern API isn't typed in stock lib.dom yet; fall back to the
+  // ubiquitous Chromium one.
+  type WithEntry = DataTransferItem & {
+    getAsEntry?: () => FileSystemEntry | null;
+    webkitGetAsEntry?: () => FileSystemEntry | null;
+  };
+  const i = item as WithEntry;
+  return i.webkitGetAsEntry?.() ?? i.getAsEntry?.() ?? null;
+}
+
+async function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+  // readEntries returns at most ~100 entries per call; loop until it
+  // returns empty.
+  const out: FileSystemEntry[] = [];
+  for (;;) {
+    const batch: FileSystemEntry[] = await new Promise((resolve, reject) =>
+      reader.readEntries((entries) => resolve(entries as FileSystemEntry[]), reject),
+    );
+    if (batch.length === 0) return out;
+    out.push(...batch);
+  }
+}
+
+function getFile(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
 
 /// Join a parent dir and a filename while keeping root (`/`) tidy.
 function joinRemote(dir: string, name: string): string {
@@ -36,6 +83,8 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
   const [dragOver, setDragOver] = useState(false);
   const [prompt, setPrompt] = useState<PendingPrompt | null>(null);
   const [confirm, setConfirm] = useState<PendingConfirm | null>(null);
+  const [dirJobs, setDirJobs] = useState<DirJob[]>([]);
+  const nextDirJobId = useRef(1);
   const setCwd = useTabs((s) => s.setCwd);
 
   const refresh = useCallback(async () => {
@@ -107,39 +156,153 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
     setMenu({ x, y, items });
   }
 
-  /// Drag-drop upload. Chromium webviews don't expose a source file path
-  /// on HTML5 drops (security), so we read each File's bytes via
-  /// FileReader and ship them to `sftp_upload_bytes`, which streams the
-  /// buffer into the remote SFTP session. This works regardless of the
-  /// host OS — path separators, drive letters, and POSIX roots are all
-  /// handled by the backend's `normalise_remote_path` on the target side.
-  async function handleDrop(ev: React.DragEvent) {
-    ev.preventDefault();
-    setDragOver(false);
-    const cid = tab.connectionId;
-    if (cid == null) return;
-    const files = Array.from(ev.dataTransfer?.files ?? []) as File[];
-    if (files.length === 0) return;
-    for (const f of files) {
-      try {
-        if (f.size > 256 * 1024 * 1024) {
-          toast.danger(
-            'File too large',
-            `${f.name} is ${(f.size / (1024 * 1024)).toFixed(1)} MB — drag-drop cap is 256 MB. Use the Upload button.`,
-          );
-          continue;
-        }
-        // `File.name` is just the base name in every browser — perfect
-        // for joining with the remote cwd; no need to strip separators.
-        const remote = joinRemote(tab.cwd, f.name || 'upload');
-        const bytes = Array.from(new Uint8Array(await f.arrayBuffer()));
-        const t = await api.sftpUploadBytes(cid, remote, bytes);
-        setTransfers((prev) => [...prev, { transferId: t.transfer_id, label: `upload ${f.name}` }]);
-      } catch (er) {
-        toast.danger(`Upload failed: ${f.name}`, errMessage(er));
+  /// Single-file upload over SFTP. Chromium webviews don't expose a
+  /// source file path on HTML5 drops (security), so we read each File's
+  /// bytes via FileReader and ship them to `sftp_upload_bytes`, which
+  /// streams the buffer into the remote SFTP session.
+  async function uploadOneFile(cid: number, f: File, remotePath: string): Promise<boolean> {
+    if (f.size > UPLOAD_CAP_BYTES) {
+      toast.danger(
+        'File too large',
+        `${f.name} is ${(f.size / (1024 * 1024)).toFixed(1)} MB — drag-drop cap is 256 MB. Use the Upload button.`,
+      );
+      return false;
+    }
+    try {
+      const bytes = Array.from(new Uint8Array(await f.arrayBuffer()));
+      const t = await api.sftpUploadBytes(cid, remotePath, bytes);
+      setTransfers((prev) => [...prev, { transferId: t.transfer_id, label: `upload ${f.name}` }]);
+      return true;
+    } catch (er) {
+      toast.danger(`Upload failed: ${f.name}`, errMessage(er));
+      return false;
+    }
+  }
+
+  /// Idempotent mkdir: best-effort, swallows "exists" errors so a
+  /// directory tree can be re-uploaded over itself. We don't list
+  /// first because that's a round-trip; trying to create and tolerating
+  /// the failure is one IPC.
+  async function ensureRemoteDir(cid: number, path: string): Promise<void> {
+    try { await api.sftpMkdir(cid, path); } catch { /* assume already exists */ }
+  }
+
+  /// Walk a dropped FileSystemDirectoryEntry, mkdir its descendants on
+  /// the remote and upload each leaf file. Updates the supplied DirJob
+  /// as we go so the in-pane progress strip shows total / done counts.
+  async function uploadDirectoryEntry(
+    cid: number,
+    dirEntry: FileSystemDirectoryEntry,
+    remoteRoot: string,
+    jobId: number,
+  ): Promise<void> {
+    const reader = dirEntry.createReader();
+    const children = await readAllEntries(reader);
+    for (const child of children) {
+      const childRemote = joinRemote(remoteRoot, child.name);
+      if (child.isDirectory) {
+        await ensureRemoteDir(cid, childRemote);
+        setDirJobs((js) =>
+          js.map((j) => (j.id === jobId ? { ...j, total: j.total + 1, done: j.done + 1 } : j)),
+        );
+        await uploadDirectoryEntry(cid, child as FileSystemDirectoryEntry, childRemote, jobId);
+      } else {
+        const f = await getFile(child as FileSystemFileEntry).catch(() => null);
+        setDirJobs((js) =>
+          js.map((j) => (j.id === jobId ? { ...j, total: j.total + 1 } : j)),
+        );
+        const ok = f ? await uploadOneFile(cid, f, childRemote) : false;
+        setDirJobs((js) =>
+          js.map((j) => (j.id === jobId
+            ? { ...j, done: j.done + (ok ? 1 : 0), failed: j.failed + (ok ? 0 : 1) }
+            : j),
+          ),
+        );
       }
     }
+  }
+
+  /// Shared drop handler used by both the pane-wide drop zone and the
+  /// per-folder drop targets. Mixes single files (legacy
+  /// dataTransfer.files path) with full directory walks via
+  /// webkitGetAsEntry. We don't `await` the file/directory uploads in
+  /// sequence here — Promise.all lets the parallel uploads race, which
+  /// is fine because each `sftpUploadBytes` opens its own write handle.
+  async function uploadDataTransfer(targetDir: string, dt: DataTransfer | null) {
+    const cid = tab.connectionId;
+    if (cid == null || !dt) return;
+
+    // Prefer the items API so we can detect directories. Fall back to
+    // the `files` collection on browsers that don't expose entries
+    // (none of our supported webviews, but cheap defensive code).
+    const items = Array.from(dt.items ?? []);
+    type Work = { kind: 'file'; file: File; remote: string }
+              | { kind: 'dir';  entry: FileSystemDirectoryEntry; remote: string; rootName: string };
+    const work: Work[] = [];
+
+    if (items.length > 0) {
+      for (const it of items) {
+        if (it.kind !== 'file') continue;
+        const e = entryFromItem(it);
+        if (e?.isDirectory) {
+          work.push({
+            kind: 'dir',
+            entry: e as FileSystemDirectoryEntry,
+            remote: joinRemote(targetDir, e.name),
+            rootName: e.name,
+          });
+        } else if (e?.isFile) {
+          // FileSystemFileEntry.file is async; capture the File now.
+          const f = await getFile(e as FileSystemFileEntry).catch(() => null);
+          if (f) work.push({ kind: 'file', file: f, remote: joinRemote(targetDir, f.name || 'upload') });
+        } else {
+          // Some weird-shaped DataTransferItem (text, image-data, ...). Skip.
+          const f = it.getAsFile();
+          if (f) work.push({ kind: 'file', file: f, remote: joinRemote(targetDir, f.name || 'upload') });
+        }
+      }
+    } else {
+      for (const f of Array.from(dt.files ?? [])) {
+        work.push({ kind: 'file', file: f, remote: joinRemote(targetDir, f.name || 'upload') });
+      }
+    }
+
+    if (work.length === 0) return;
+
+    const dirWork = work.filter((w): w is Extract<Work, { kind: 'dir' }> => w.kind === 'dir');
+    const fileWork = work.filter((w): w is Extract<Work, { kind: 'file' }> => w.kind === 'file');
+
+    for (const f of fileWork) {
+      void uploadOneFile(cid, f.file, f.remote);
+    }
+
+    for (const d of dirWork) {
+      const jobId = nextDirJobId.current++;
+      setDirJobs((js) => [...js, {
+        id: jobId, rootName: d.rootName, total: 1, done: 0, failed: 0, finished: false,
+      }]);
+      await ensureRemoteDir(cid, d.remote);
+      setDirJobs((js) => js.map((j) => (j.id === jobId ? { ...j, done: 1 } : j)));
+      try {
+        await uploadDirectoryEntry(cid, d.entry, d.remote, jobId);
+      } catch (er) {
+        toast.danger(`Directory upload failed: ${d.rootName}`, errMessage(er));
+      }
+      setDirJobs((js) => js.map((j) => (j.id === jobId ? { ...j, finished: true } : j)));
+    }
+
     setTimeout(refresh, 500);
+  }
+
+  function handleDrop(ev: React.DragEvent) {
+    ev.preventDefault();
+    setDragOver(false);
+    void uploadDataTransfer(tab.cwd, ev.dataTransfer);
+  }
+
+  function handleFolderDrop(folder: SftpEntry, ev: React.DragEvent) {
+    // Per-folder drop: upload INTO the folder, not next to it.
+    void uploadDataTransfer(folder.full_path, ev.dataTransfer);
   }
 
   async function handleUploadClick() {
@@ -241,9 +404,18 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
           <EmptyState icon={Inbox} title="Empty directory" compact />
         )}
         {entries.map((e) => (
-          <SftpFileRow key={e.full_path} entry={e} onOpen={navigateInto} onContext={openContext} />
+          <SftpFileRow
+            key={e.full_path}
+            entry={e}
+            onOpen={navigateInto}
+            onContext={openContext}
+            onFolderDrop={handleFolderDrop}
+          />
         ))}
       </div>
+      <DirectoryJobs jobs={dirJobs} onClear={(id) =>
+        setDirJobs((js) => js.filter((j) => j.id !== id))
+      } />
       <TransferStatus tracked={transfers} />
 
       {dragOver && (
@@ -317,6 +489,59 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
           }}
         />
       )}
+    </div>
+  );
+}
+
+/** Per-tree upload progress, distinct from the per-file TransferStatus
+ *  strip beneath it. Shows "uploading dir/ N of M" while we walk a
+ *  dropped folder. Finished jobs stick around as a one-line summary
+ *  until the user clicks ×; that's intentional so a user can see at a
+ *  glance whether anything failed. */
+function DirectoryJobs({
+  jobs, onClear,
+}: { jobs: DirJob[]; onClear: (id: number) => void }) {
+  if (jobs.length === 0) return null;
+  return (
+    <div className="border-t border-border bg-surface2/40 text-xs p-2 space-y-1.5">
+      {jobs.map((j) => {
+        const pct = j.total > 0 ? Math.floor((j.done / j.total) * 100) : 0;
+        const statusText = j.finished
+          ? (j.failed > 0
+              ? `done (${j.failed} failed)`
+              : `done (${j.done} files)`)
+          : `${j.done}/${j.total}`;
+        return (
+          <div key={j.id} className="space-y-0.5">
+            <div className="flex items-center gap-2">
+              <span className="flex-1 truncate text-fg/90">
+                {j.finished ? '✓ ' : ''}upload {j.rootName}/
+              </span>
+              <span className={`tabular-nums ${j.failed > 0 ? 'text-danger' : 'text-muted'}`}>
+                {statusText}
+              </span>
+              {j.finished && (
+                <button
+                  type="button"
+                  onClick={() => onClear(j.id)}
+                  aria-label="Dismiss"
+                  className="text-muted hover:text-fg leading-none px-1"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+            {!j.finished && (
+              <div className="h-1 bg-surface2 rounded-sm overflow-hidden">
+                <div
+                  className="h-full bg-accent transition-[width] duration-fast"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/ui/lib/tauri.ts
+++ b/ui/lib/tauri.ts
@@ -18,6 +18,21 @@ export function errMessage(e: unknown): string {
   return String(e);
 }
 
+/** Exposed on `window.__ezterm` in development builds (and via a
+ *  `localStorage.ezterm_dev=1` opt-in in production) so the user can
+ *  invoke `await __ezterm.dragTestFile('hello.txt', 'hi')` from the
+ *  devtools console to validate the phase-B1 drag plumbing without a
+ *  UI hookup. Drag-out integration with the SFTP rows arrives in B2
+ *  of issue #28; until then the test command is the only path. */
+export function exposeDevApi() {
+  if (typeof window === 'undefined') return;
+  const dev =
+    process.env.NODE_ENV !== 'production'
+    || (typeof localStorage !== 'undefined' && localStorage.getItem('ezterm_dev') === '1');
+  if (!dev) return;
+  (window as unknown as { __ezterm: typeof api }).__ezterm = api;
+}
+
 export const api = {
   // Vault
   vaultStatus: () => invoke<VaultStatus>('vault_status'),
@@ -118,6 +133,12 @@ export const api = {
     invoke<TransferTicket>('sftp_upload_bytes', { connectionId, remotePath, bytes }),
   sftpDownload: (connectionId: number, remotePath: string, localPath: string) =>
     invoke<TransferTicket>('sftp_download', { connectionId, remotePath, localPath }),
+  /** Phase B1 of issue #28: starts an OS-native OLE drag with a
+   *  hardcoded `body` payload exposed as a virtual file named `name`.
+   *  Windows-only today; macOS/Linux surface an "unsupported" error.
+   *  Returns 'dropped' or 'cancelled' depending on user action. */
+  dragTestFile: (name: string, body: string) =>
+    invoke<'dropped' | 'cancelled'>('drag_test_file', { name, body }),
 
   // Local PTY (WSL / cmd / pwsh)
   localConnect:    (sessionId: number, cols: number, rows: number) =>


### PR DESCRIPTION
First slice of issue #28. Drag-in is fully functional and testable on Linux/macOS/Windows; drag-out is a Windows-only scaffold that needs your validation on real Windows hardware before we layer SFTP integration on top.

## Summary
- **A1**: each SFTP folder row is now a drop target. Drop onto a folder → uploads INTO it; drop onto pane background → uploads to current cwd. Visual highlight on the folder row while dragged over.
- **A2**: directory uploads via `webkitGetAsEntry`. Walks dropped trees, `sftpMkdir` each remote folder (idempotent so re-uploads work), uploads each leaf file via `sftp_upload_bytes` (256 MB cap unchanged).
- **A4**: new in-pane `DirectoryJobs` strip above the existing `TransferStatus` shows live `N / M` count during the tree walk; finished jobs show a one-line summary with a `×` button.
- **B1 (Windows scaffold)**: full OLE drag-source implementation. `IDataObject` (FILEGROUPDESCRIPTORW + FILECONTENTS), `IEnumFORMATETC`, `IDropSource`, `IStream` (over an in-memory `Vec<u8>`). New `drag_test_file(name, body)` Tauri command spawns a dedicated thread, runs `OleInitialize` + `DoDragDrop`. Non-Windows platforms get an "unsupported" error pending phases B5/B6.

## Test plan (run on Windows after installer build)
- [ ] Drop a single file onto the SFTP pane background → uploads to cwd.
- [ ] Drop a single file onto a folder row → uploads into that folder. Row highlights during drag.
- [ ] Drop multiple files onto the pane → each gets its own TransferStatus entry.
- [ ] Drop a folder onto the pane → the entire tree mirrors to the remote, DirectoryJobs shows `N / M` while running, then `done (X files)`.
- [ ] Drop a folder onto a folder row → uploads INTO that target folder.
- [ ] Re-drop the same folder (overlap with existing remote dirs) → no errors, files re-upload.
- [ ] Open devtools console, run \`await __ezterm.dragTestFile('hello.txt', 'hi')\`. Drag the cursor onto Explorer. **Expected**: a file named \`hello.txt\` appears with content \`hi\`. Command returns \`'dropped'\`.
- [ ] Same as above but press Escape mid-drag → command returns \`'cancelled'\`, no file created.
- [ ] On Linux/macOS, calling \`__ezterm.dragTestFile\` returns a "not yet implemented" validation error.

## Test plan (already verified here)
- [x] \`cargo check\` (Linux native) — clean.
- [x] \`cargo check --target x86_64-pc-windows-gnu\` — clean.
- [x] \`cargo test --bin ezterm\` — 87 / 87 pass.
- [x] \`npm run lint\` — 6 pre-existing warnings, 0 new.

## What's deferred
Issue #28 phases B2 (SFTP integration, pre-buffered), B3 (streaming `IStream`), B4 (multi-file / directory drag-out), B5 (macOS), B6 (Linux), B7 (polish), and A3 (streaming uploads to lift the 256 MB cap) are explicit follow-ups. The roadmap is at the top of issue #28.

If \`dragTestFile\` lands a file in Explorer end-to-end, the next PR will layer B2 (SFTP fetch into a `Vec<u8>` before drag) on top of the existing scaffold.