### PR TITLE
fix(local-shell): spawn Unix local shell as interactive, not login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "argon2",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/src-tauri/src/local/mod.rs
+++ b/src-tauri/src/local/mod.rs
@@ -236,9 +236,12 @@ fn build_local_command(program: &str, extra: &str) -> Result<CommandBuilder> {
 /// path (e.g. `/bin/bash`); blank falls back to `$SHELL` then `/bin/sh`.
 /// `extra` is an optional cwd, mirroring Windows local semantics.
 ///
-/// Always invoked as a login shell (`-l`). On macOS especially, Terminal.app
-/// runs login shells so PATH and the user's profile env (Homebrew, asdf,
-/// etc.) are populated; matching that avoids "command not found" surprises.
+/// Invoked as an interactive shell (`-i`), matching gnome-terminal /
+/// Konsole / iTerm defaults: `~/.bashrc` (and `~/.zshrc` etc.) load
+/// reliably, so users' PATH and exports from the rc file are picked up.
+/// A bare `-l` login shell only reads `~/.profile` / `~/.bash_profile`
+/// and skips the rc file unless the user wired it up themselves, which
+/// surprised users with "env vars don't load" reports (#104).
 #[cfg(unix)]
 fn build_local_command(program: &str, extra: &str) -> Result<CommandBuilder> {
     let shell = match program.trim() {
@@ -246,7 +249,7 @@ fn build_local_command(program: &str, extra: &str) -> Result<CommandBuilder> {
         other => other.to_string(),
     };
     let mut c = CommandBuilder::new(&shell);
-    c.arg("-l");
+    c.arg("-i");
     let cwd = extra.trim();
     if !cwd.is_empty() {
         c.cwd(cwd);


### PR DESCRIPTION
## Summary
- Switch Unix local shells from `bash -l` (login) to `bash -i` (interactive) so `~/.bashrc` / `~/.zshrc` actually load. Matches gnome-terminal / Konsole / iTerm defaults.
- Bump workspace version to 1.6.1 (patch — bug fix).

## Why
Login shells (`-l`) read `/etc/profile` and `~/.profile` / `~/.bash_profile`, but **skip** `~/.bashrc` unless the user's profile sources it explicitly. Most Linux users keep PATH and exports in `~/.bashrc`, so env vars appeared not to load when launching a Local Shell.

Reporter also noted MOTD was missing — that's not a bug. `pam_motd` only runs on a real PAM login (sshd, `login`); no terminal emulator's spawned shell triggers it. Mentioning here so it doesn't get re-filed.

Closes #104.

## Test plan
- [ ] Linux: open a Local Shell, run `echo \$PATH` and any custom export from your `.bashrc` — should match a regular gnome-terminal session.
- [ ] Linux: confirm any alias from `.bashrc` works (e.g. `alias ll`).
- [ ] macOS: open a Local Shell, run `echo \$PATH` — Homebrew/asdf-managed PATH should still resolve via the user's `.zshrc`/`.bashrc`.
- [ ] Sanity-check zsh + fish if available — `-i` is the standard interactive flag for all three.