### PR TITLE
fix(sftp): multi-file download + multi-file Upload button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "argon2",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/ui/components/sftp-pane.tsx
+++ b/ui/components/sftp-pane.tsx
@@ -175,7 +175,47 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
     const cid = tab.connectionId;
     if (cid == null) return;
     const items: MenuItem[] = [];
-    if (!e.is_dir) {
+    // If the right-clicked file is part of an active multi-selection,
+    // Download applies to every selected non-directory entry and prompts
+    // once for a destination folder. Otherwise it falls back to the
+    // single-file save-as flow on the right-clicked entry.
+    const multiTargets =
+      !e.is_dir && selected.has(e.full_path) && selected.size > 1
+        ? entries.filter((ent) => selected.has(ent.full_path) && !ent.is_dir)
+        : null;
+    if (multiTargets && multiTargets.length > 1) {
+      items.push({
+        label: `Download ${multiTargets.length} files…`,
+        onClick: async () => {
+          try {
+            const destDir = await openDialog({
+              directory: true,
+              multiple: false,
+              title: 'Download to folder',
+            });
+            if (typeof destDir !== 'string') return;
+            // Honour the OS path separator implied by the picked
+            // folder. Tauri's open-dialog returns native paths, so a
+            // Windows pick contains `\` and a POSIX pick contains `/`.
+            const sep = destDir.includes('\\') && !destDir.includes('/') ? '\\' : '/';
+            const base = destDir.replace(/[\\/]+$/, '');
+            const newTransfers: TrackedTransfer[] = [];
+            for (const ent of multiTargets) {
+              try {
+                const localPath = `${base}${sep}${ent.name}`;
+                const t = await api.sftpDownload(cid, ent.full_path, localPath);
+                newTransfers.push({ transferId: t.transfer_id, label: `download ${ent.name}` });
+              } catch (er) {
+                toast.danger(`Download failed: ${ent.name}`, errMessage(er));
+              }
+            }
+            if (newTransfers.length) setTransfers((prev) => [...prev, ...newTransfers]);
+          } catch (er) {
+            toast.danger('Download failed', errMessage(er));
+          }
+        },
+      });
+    } else if (!e.is_dir) {
       items.push({
         label: 'Download…',
         onClick: async () => {

--- a/ui/components/sftp-pane.tsx
+++ b/ui/components/sftp-pane.tsx
@@ -472,12 +472,23 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
     const cid = tab.connectionId;
     if (cid == null) return;
     try {
-      const picked = await openDialog({ multiple: false });
-      if (typeof picked !== 'string') return;
-      const name = picked.split(/[\\/]/).pop() ?? 'upload';
-      const remote = joinRemote(tab.cwd, name);
-      const t = await api.sftpUpload(cid, picked, remote);
-      setTransfers((prev) => [...prev, { transferId: t.transfer_id, label: `upload ${name}` }]);
+      const picked = await openDialog({ multiple: true });
+      // Tauri returns string | string[] | null depending on `multiple`.
+      // Normalise to an array so the loop below handles both shapes.
+      const paths = Array.isArray(picked) ? picked : typeof picked === 'string' ? [picked] : [];
+      if (paths.length === 0) return;
+      const newTransfers: TrackedTransfer[] = [];
+      for (const p of paths) {
+        const name = p.split(/[\\/]/).pop() ?? 'upload';
+        const remote = joinRemote(tab.cwd, name);
+        try {
+          const t = await api.sftpUpload(cid, p, remote);
+          newTransfers.push({ transferId: t.transfer_id, label: `upload ${name}` });
+        } catch (er) {
+          toast.danger(`Upload failed: ${name}`, errMessage(er));
+        }
+      }
+      if (newTransfers.length) setTransfers((prev) => [...prev, ...newTransfers]);
       setTimeout(refresh, 500);
     } catch (er) {
       toast.danger('Upload failed', errMessage(er));
@@ -521,8 +532,8 @@ export function SftpPane({ tab, isVisible = true }: { tab: Tab; isVisible?: bool
         <button
           type="button"
           onClick={handleUploadClick}
-          title="Upload file"
-          aria-label="Upload file"
+          title="Upload files"
+          aria-label="Upload files"
           className="icon-btn"
         >
           <Upload size={13} />


### PR DESCRIPTION
## Summary
Two related multi-file gaps in the SFTP panel:

**1. Download (context menu)** — right-clicking a file only ever downloaded the right-clicked entry, ignoring any active multi-selection.
- When the clicked file is part of a multi-selection, the menu now reads **"Download N files…"**, prompts **once** for a destination folder, and downloads every selected non-directory file into that folder.
- Single-file right-click is unchanged (save-as picker).
- Directories in the selection are filtered out — `sftp_download` is file-only.

**2. Upload button (toolbar)** — the file picker was `multiple: false`, so the button could only upload one file at a time.
- Now `multiple: true`; each picked file goes through `sftpUpload` and registers its own row in the transfer-progress strip.
- Per-file errors surface as their own toast and don't abort the rest of the batch.
- Button title/aria-label updated to "Upload files".

Drag-drop already supported multi-file (verified in `uploadDataTransfer`, line ~351) — no change there.

Bumps workspace version to 1.6.1.

## Test plan

**Download:**
- [ ] Ctrl-click 3+ files, right-click a selected row → menu shows "Download 3 files…".
- [ ] Click it → single folder picker → all 3 land in that folder, each with its own progress row.
- [ ] Right-click a single (unselected) file → menu still shows "Download…" and uses the save-as picker.
- [ ] Mix of files + directories selected → directories silently skipped on the file path.
- [ ] Windows: confirm `C:\Users\…\file.ext` paths are constructed correctly.

**Upload:**
- [ ] Click the Upload button → file dialog allows multi-select (Ctrl/Shift-click).
- [ ] Pick several files → each appears as its own transfer in the progress strip.
- [ ] Cancel the dialog → no toast / no transfers added.
- [ ] One bad-permission file in a batch → only that file's toast fires; the rest still upload.

**Drag-drop (regression check, unchanged code):**
- [ ] Drag 5+ files from OS file manager onto the SFTP pane → all upload.
- [ ] Drag a folder → walks recursively (existing dirJob progress).