### PR TITLE
fix: tab/sidebar drag freezes app on Linux — replace HTML5 DnD with pointer events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.7.3"
+version = "1.7.4"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.7.2"
+version = "1.7.3"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/docs/release-notes/v1.7.4.md
+++ b/docs/release-notes/v1.7.4.md
@@ -1,0 +1,33 @@
+# ezTerm v1.7.4
+
+Patch on top of v1.7.2: re-arranging tabs (or sidebar sessions) while connections are live no longer freezes the app on Linux, and drag-reorder got an across-the-board hardening pass.
+
+## What changed
+
+### Tab / sidebar drag no longer freezes the app on Linux — fix (#109)
+
+- **`ui/lib/pointer-drag.ts`** (new) — the tab bar and the sessions tree used native HTML5 drag-and-drop, which on Linux runs through WebKitGTK's drag implementation. That implementation can take the pointer grab and never release it ([WebKit bug 32840](https://bugs.webkit.org/show_bug.cgi?id=32840)): drag-end never fires and the whole window stops responding. Both surfaces now use a shared pointer-event drag helper that stays entirely inside the webview's event loop — identical behavior on Windows, macOS, and Linux.
+- **`ui/components/main-shell.tsx`** — anchors and selected text are natively draggable in WebKit even with no `draggable` attribute, so a window-level `dragstart` guard now blocks *all* in-page native drag initiation. Dropping files from your OS into the SFTP pane is unaffected (external drags never fire an in-page `dragstart`).
+- Drop-slot semantics are unchanged: same midpoint left/right tab indicators, same 50/50 session and 25/50/25 folder splits in the tree, same backend calls.
+
+### Drag-reorder hardening
+
+- **Abort gestures work**: moving the pointer away from the tab strip clears the drop indicator and releasing there cancels the drag (previously any release reordered); `Escape` cancels mid-drag without the subsequent mouse release clicking whatever it lands on.
+- **No phantom drops**: a release outside the window can no longer leave a drag armed where the next click would commit it.
+- **Self-drops are no-ops**: wiggling a session a few pixels on its own row no longer silently jumps it to the top of its folder.
+- **Stable under mutation**: the dragged tab is tracked by id, not index, so a tab closing mid-drag can't make the wrong tab move; sidebar drops are computed from drop-time data, not a stale snapshot.
+- **Cheaper while terminals stream**: drag hit-testing is coalesced to one pass per frame and the terminal area no longer re-renders on drop-indicator changes — less jank when dragging while SSH output is pouring in.
+
+### Housekeeping
+
+- **`src-tauri/src/xserver/mod.rs`** — the Windows-only VcXsrv installer URL constant is now cfg-gated, clearing a `dead_code` warning on non-Windows builds.
+
+## Verify
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Licence
+
+**GPL v3** (version 3 only). See [LICENSE](../blob/main/LICENSE).

--- a/src-tauri/src/xserver/mod.rs
+++ b/src-tauri/src/xserver/mod.rs
@@ -183,6 +183,7 @@ pub fn user_install_path() -> Option<PathBuf> {
 /// hops by default. Pinned to 1.20.14.0 (current stable as of 2026-Q2)
 /// so the install surface is deterministic. The installer is an NSIS
 /// EXE — we drive it with `/S /D=<target>` below.
+#[cfg(target_os = "windows")]
 const VCXSRV_INSTALLER_URL: &str =
     "https://sourceforge.net/projects/vcxsrv/files/vcxsrv/1.20.14.0/\
      vcxsrv-64.1.20.14.0.installer.exe/download";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.7.1",
+  "version": "1.7.3",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/components/main-shell.tsx
+++ b/ui/components/main-shell.tsx
@@ -38,6 +38,19 @@ export function MainShell({ onLock }: { onLock: () => void }) {
     localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
   }, [width]);
 
+  // Block ALL in-page native drag initiation. WebKitGTK's HTML5 drag can
+  // take the pointer grab and never release it, hard-freezing the app on
+  // Linux (#109) — and anchors and selected text are natively draggable
+  // even with no `draggable` attribute anywhere. The app has no legitimate
+  // in-page drag sources (tab/tree reordering uses pointer events, see
+  // lib/pointer-drag.ts), and OS file drops into the SFTP pane are
+  // unaffected: external drags never fire an in-page `dragstart`.
+  useEffect(() => {
+    const block = (e: DragEvent) => e.preventDefault();
+    window.addEventListener('dragstart', block);
+    return () => window.removeEventListener('dragstart', block);
+  }, []);
+
   // Auto-update check — cadence-gated (30d default) so we don't hit the
   // GitHub Releases endpoint on every unlock. If an update is waiting,
   // surface a prompt via UpdateDialog; the user can always dismiss and

--- a/ui/components/mdi-area.tsx
+++ b/ui/components/mdi-area.tsx
@@ -1,12 +1,15 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { Terminal } from 'lucide-react';
 import { useTabs } from '@/lib/tabs-store';
 import { EmptyState } from './empty-state';
 import { TabSlot } from './tab-slot';
 import { MinimizedStrip } from './minimized-strip';
 
-export function MdiArea() {
+// memo: the parent TabsShell re-renders on every drag-indicator change
+// while a tab is being dragged; MdiArea takes no props and subscribes to
+// the tabs store itself, so those parent renders are pure waste here.
+export const MdiArea = memo(function MdiArea() {
   const tabs      = useTabs((s) => s.tabs);
   const activeId  = useTabs((s) => s.activeId);
   const viewMode  = useTabs((s) => s.viewMode);
@@ -121,4 +124,4 @@ export function MdiArea() {
       {viewMode === 'cascade' && <MinimizedStrip />}
     </div>
   );
-}
+});

--- a/ui/components/sessions-sidebar.tsx
+++ b/ui/components/sessions-sidebar.tsx
@@ -499,16 +499,30 @@ export function SessionsSidebar() {
   //
   // The drag source is mirrored into a ref because the move/drop callbacks
   // close over the render where the drag started; state drives only the
-  // opacity / highlight visuals. dragTargetRef likewise keeps slot dedupe
-  // accurate across renders so pointermove doesn't re-render every tick.
+  // opacity / highlight visuals. sessionsRef/foldersRef are live mirrors of
+  // the data arrays for the same reason — a reload() can resolve mid-drag,
+  // and the drop must be computed from drop-time data, not the snapshot
+  // captured at pointerdown.
   const dragSourceRef = useRef<{ kind: 'session' | 'folder'; id: number } | null>(null);
-  const dragTargetRef = useRef<DropSlot | null>(null);
   const treeRef = useRef<HTMLDivElement>(null);
+  const sessionsRef = useRef(sessions);
+  const foldersRef = useRef(folders);
+  useEffect(() => {
+    sessionsRef.current = sessions;
+    foldersRef.current = folders;
+  }, [sessions, folders]);
+
+  // Tear down an in-flight drag if the sidebar unmounts (Ctrl+B toggles it
+  // out of the tree) — the helper's window listeners would otherwise
+  // outlive it with stale closures.
+  const dragCancelRef = useRef<(() => void) | undefined>(undefined);
+  useEffect(() => () => dragCancelRef.current?.(), []);
 
   function setDragTargetIfChanged(next: DropSlot | null) {
-    if (slotsEqual(dragTargetRef.current, next)) return;
-    dragTargetRef.current = next;
-    setDragTarget(next);
+    // Functional updater: `prev` is never stale even though this closure
+    // was created at pointerdown, and React bails out of the re-render
+    // when the updater returns the previous value.
+    setDragTarget((prev) => (slotsEqual(prev, next) ? prev : next));
   }
 
   /** Compute the slot for the row-aware drag position.
@@ -559,16 +573,24 @@ export function SessionsSidebar() {
     return null;
   }
 
-  /** Can't drop a folder into itself (either as a parent or as its own
-   *  sibling-edge). before/after-folder on self is a no-op drop, but we
-   *  still reject to avoid a confusing indicator line. Deeper cycles
-   *  (into a descendant) are rejected by the backend at drop time. */
+  /** Can't drop a row onto itself: a folder into/beside itself, or a
+   *  session before/after itself (which would otherwise resolve anchor ===
+   *  dragged in buildOrderForSessionDrop and silently jump the session to
+   *  the top of its folder). Rejecting also suppresses the indicator line
+   *  on the dragged row. Deeper cycles (folder into a descendant) are
+   *  rejected by the backend at drop time. */
   function slotRejected(slot: DropSlot): boolean {
     const src = dragSourceRef.current;
-    if (!src || src.kind !== 'folder') return false;
+    if (!src) return false;
+    if (src.kind === 'folder') {
+      return (
+        (slot.kind === 'into-folder' || slot.kind === 'before-folder' || slot.kind === 'after-folder')
+        && slot.folderId === src.id
+      );
+    }
     return (
-      (slot.kind === 'into-folder' || slot.kind === 'before-folder' || slot.kind === 'after-folder')
-      && slot.folderId === src.id
+      (slot.kind === 'before-session' || slot.kind === 'after-session')
+      && slot.sessionId === src.id
     );
   }
 
@@ -577,9 +599,7 @@ export function SessionsSidebar() {
     kind: 'session' | 'folder',
     id: number,
   ) {
-    // Buttons inside a row (delete) are clicks, never drag handles.
-    if ((e.target as HTMLElement).closest('button')) return;
-    beginPointerDrag(e, {
+    dragCancelRef.current = beginPointerDrag(e, {
       onDragStart: () => {
         dragSourceRef.current = { kind, id };
         setDrag({ kind, id });
@@ -594,7 +614,6 @@ export function SessionsSidebar() {
       },
       onEnd: () => {
         dragSourceRef.current = null;
-        dragTargetRef.current = null;
         setDrag(null);
         setDragTarget(null);
       },
@@ -626,7 +645,9 @@ export function SessionsSidebar() {
     // in one gesture works). Folder-edge drops aren't a valid destination
     // for a session; treat them as "move into that folder's parent and
     // reorder" — we position just above/below the folder in its parent.
-    const cur = sessions.find((s) => s.id === sessionId);
+    // Read through the refs: this runs in a closure captured at
+    // pointerdown, and the lists may have reloaded since.
+    const cur = sessionsRef.current.find((s) => s.id === sessionId);
     if (!cur) return;
 
     const destFolderId = resolveDestFolderId(slot);
@@ -653,7 +674,7 @@ export function SessionsSidebar() {
       await api.sessionMove(sessionId, destFolderId, 0);
     }
     // Build new order among sessions in destFolderId.
-    const existingInDest = sessions
+    const existingInDest = sessionsRef.current
       .filter((s) => s.folder_id === destFolderId && s.id !== sessionId)
       .sort((a, b) => a.sort - b.sort || a.id - b.id)
       .map((s) => s.id);
@@ -664,7 +685,7 @@ export function SessionsSidebar() {
   }
 
   async function dropFolder(folderId: number, slot: DropSlot) {
-    const cur = folders.find((f) => f.id === folderId);
+    const cur = foldersRef.current.find((f) => f.id === folderId);
     if (!cur) return;
     if (slot.kind === 'into-folder' && slot.folderId === folderId) return;
 
@@ -688,7 +709,7 @@ export function SessionsSidebar() {
     if (crossParent) {
       await api.folderMove(folderId, destParentId, 0);
     }
-    const existingInDest = folders
+    const existingInDest = foldersRef.current
       .filter((f) => f.parent_id === destParentId && f.id !== folderId)
       .sort((a, b) => a.sort - b.sort || a.id - b.id)
       .map((f) => f.id);
@@ -705,12 +726,12 @@ export function SessionsSidebar() {
         return slot.folderId;
       case 'before-session':
       case 'after-session': {
-        const sib = sessions.find((s) => s.id === slot.sessionId);
+        const sib = sessionsRef.current.find((s) => s.id === slot.sessionId);
         return sib ? sib.folder_id : undefined;
       }
       case 'before-folder':
       case 'after-folder': {
-        const sib = folders.find((f) => f.id === slot.folderId);
+        const sib = foldersRef.current.find((f) => f.id === slot.folderId);
         return sib ? sib.parent_id : undefined;
       }
     }

--- a/ui/components/sessions-sidebar.tsx
+++ b/ui/components/sessions-sidebar.tsx
@@ -39,6 +39,7 @@ function DropLine({ edge }: { edge: 'top' | 'bottom' }) {
 }
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { api, errMessage } from '@/lib/tauri';
+import { beginPointerDrag } from '@/lib/pointer-drag';
 import type { Folder as TFolder, Session } from '@/lib/types';
 import { useTabs } from '@/lib/tabs-store';
 import { toast } from '@/lib/toast';
@@ -136,11 +137,7 @@ interface NodeViewCtx {
   drag:                { kind: 'session' | 'folder'; id: number } | null;
   dragTarget:          DropSlot | null;
   selectedId:          number | null;
-  handleDragStart:     (e: React.DragEvent, kind: 'session' | 'folder', id: number) => void;
-  handleDragEnd:       () => void;
-  handleDragOver:      (e: React.DragEvent, slot: DropSlot) => void;
-  handleDrop:          (e: React.DragEvent, slot: DropSlot) => Promise<void>;
-  slotForRow:          (e: React.DragEvent, row: 'session' | 'folder', id: number) => DropSlot;
+  handlePointerDown:   (e: React.PointerEvent, kind: 'session' | 'folder', id: number) => void;
   toggleFolder:        (id: number) => void;
   openFolderMenu:      (e: React.MouseEvent, f: TFolder | null) => void;
   openSessionMenu:     (e: React.MouseEvent, s: Session) => void;
@@ -152,8 +149,7 @@ interface NodeViewCtx {
 // Top-level so the function identity is stable across SessionsSidebar
 // re-renders. If NodeView were defined inside SessionsSidebar, every
 // setState would give it a new identity and React would unmount + remount
-// the whole tree — which aborts in-flight HTML5 drags by ripping the
-// source DOM out from under the browser.
+// the whole tree — losing scroll position and hover state mid-drag.
 function NodeView({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: NodeViewCtx }) {
   const isOpen = node.folder ? ctx.expanded.has(node.folder.id) : true;
   const FolderIcon = isOpen ? FolderOpen : Folder;
@@ -177,11 +173,9 @@ function NodeView({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: No
     <div>
       {node.folder && (
         <div
-          draggable
-          onDragStart={(e) => ctx.handleDragStart(e, 'folder', node.folder!.id)}
-          onDragEnd={ctx.handleDragEnd}
-          onDragOver={(e) => ctx.handleDragOver(e, ctx.slotForRow(e, 'folder', node.folder!.id))}
-          onDrop={(e) => ctx.handleDrop(e, ctx.slotForRow(e, 'folder', node.folder!.id))}
+          data-dnd-kind="folder"
+          data-dnd-id={node.folder.id}
+          onPointerDown={(e) => ctx.handlePointerDown(e, 'folder', node.folder!.id)}
           onClick={() => ctx.toggleFolder(node.folder!.id)}
           onContextMenu={(e) => ctx.openFolderMenu(e, node.folder!)}
           className={`group relative h-7 flex items-center gap-1.5 cursor-default select-none pr-2 transition-colors ${
@@ -246,25 +240,12 @@ function NodeView({ node, depth, ctx }: { node: TreeNode; depth: number; ctx: No
             return (
               <div
                 key={s.id}
-                draggable
-                onDragStart={(e) => ctx.handleDragStart(e, 'session', s.id)}
-                onDragEnd={ctx.handleDragEnd}
+                data-dnd-kind="session"
+                data-dnd-id={s.id}
+                onPointerDown={(e) => ctx.handlePointerDown(e, 'session', s.id)}
                 onClick={() => ctx.setSelectedId(s.id)}
                 onContextMenu={(e) => ctx.openSessionMenu(e, s)}
                 onDoubleClick={() => ctx.openTabAction(s)}
-                onDragOver={(e) => {
-                  if (!ctx.drag) return;
-                  // Split the row 50/50: top half places the dragged item
-                  // *before* this session, bottom half *after*. Works for
-                  // both same-folder reordering and cross-folder moves
-                  // (the drop handler resolves destFolderId from the
-                  // anchor session's folder).
-                  ctx.handleDragOver(e, ctx.slotForRow(e, 'session', s.id));
-                }}
-                onDrop={(e) => {
-                  if (!ctx.drag) return;
-                  ctx.handleDrop(e, ctx.slotForRow(e, 'session', s.id));
-                }}
                 className={`group relative h-7 flex items-center gap-2 cursor-default select-none pr-2 transition-colors ${
                   isSelected
                     ? 'bg-accent/18 text-fg'
@@ -509,41 +490,28 @@ export function SessionsSidebar() {
 
   // --- Drag & drop ------------------------------------------------------
   //
-  // HTML5 DnD. The dragged row puts {kind,id} into dataTransfer so the drop
-  // handler can route to api.sessionMove / folderMove. Sort is always 0 on
-  // drop (new-top-of-folder); intra-folder reordering is a separate pass.
+  // Pointer-event dragging (NOT HTML5 DnD — WebKitGTK's native drag can
+  // hold the pointer grab forever and freeze the app on Linux, see #109).
+  // beginPointerDrag installs window-level listeners; the hovered drop slot
+  // is resolved by hit-testing `data-dnd-*` rows under the pointer. Sort is
+  // always 0 on an `into-*` drop (new-top-of-folder); before/after slots
+  // reorder via the full-list API.
   //
-  // React 19 batches setState more aggressively than 18, so the first few
-  // `dragover` events fire before the `drag` state update from `dragstart`
-  // has rendered — gating `preventDefault()` on the state value left the
-  // browser marking the target as a non-drop zone, and `drop` never fired.
-  // Mirror the drag source into a ref for synchronous access; state is
-  // still used for the opacity / highlight visuals.
+  // The drag source is mirrored into a ref because the move/drop callbacks
+  // close over the render where the drag started; state drives only the
+  // opacity / highlight visuals. dragTargetRef likewise keeps slot dedupe
+  // accurate across renders so pointermove doesn't re-render every tick.
   const dragSourceRef = useRef<{ kind: 'session' | 'folder'; id: number } | null>(null);
-
-  function handleDragStart(
-    e: React.DragEvent,
-    kind: 'session' | 'folder',
-    id: number,
-  ) {
-    e.stopPropagation();
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('application/json', JSON.stringify({ kind, id }));
-    dragSourceRef.current = { kind, id };
-    setDrag({ kind, id });
-  }
-
-  function handleDragEnd() {
-    dragSourceRef.current = null;
-    setDrag(null);
-    setDragTarget(null);
-  }
+  const dragTargetRef = useRef<DropSlot | null>(null);
+  const treeRef = useRef<HTMLDivElement>(null);
 
   function setDragTargetIfChanged(next: DropSlot | null) {
-    if (!slotsEqual(dragTarget, next)) setDragTarget(next);
+    if (slotsEqual(dragTargetRef.current, next)) return;
+    dragTargetRef.current = next;
+    setDragTarget(next);
   }
 
-  /** Compute the slot for a row-aware drag.
+  /** Compute the slot for the row-aware drag position.
    *
    *  Sessions split 50/50 above/below for sibling reorder.
    *
@@ -556,13 +524,12 @@ export function SessionsSidebar() {
    *    the narrow ~14px middle band (25% of a 28px row) made dropping a
    *    session *into* a folder feel broken — see #72. */
   function slotForRow(
-    e: React.DragEvent,
+    rect: DOMRect,
+    clientY: number,
     row: 'session' | 'folder',
     id: number,
   ): DropSlot {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const y = e.clientY - rect.top;
-    const ratio = rect.height > 0 ? y / rect.height : 0.5;
+    const ratio = rect.height > 0 ? (clientY - rect.top) / rect.height : 0.5;
     if (row === 'session') {
       return ratio < 0.5
         ? { kind: 'before-session', sessionId: id }
@@ -576,34 +543,70 @@ export function SessionsSidebar() {
     return { kind: 'into-folder', folderId: id };
   }
 
-  function handleDragOver(e: React.DragEvent, slot: DropSlot) {
-    const src = dragSourceRef.current;
-    if (src) {
-      // Can't drop a folder into itself (either as a parent or as its own
-      // sibling-edge). before/after-folder on self is a no-op drop, but we
-      // still reject to avoid a confusing indicator line.
-      if (src.kind === 'folder' && slot.kind === 'into-folder' && slot.folderId === src.id) return;
-      if (src.kind === 'folder' && (slot.kind === 'before-folder' || slot.kind === 'after-folder') && slot.folderId === src.id) return;
+  /** Drop slot under the pointer: a `data-dnd-*` row resolves via
+   *  slotForRow; bare tree whitespace is "move to root"; anywhere else
+   *  (terminal area, toolbar) is not a drop target. */
+  function slotAtPoint(x: number, y: number): DropSlot | null {
+    const el = document.elementFromPoint(x, y) as HTMLElement | null;
+    if (!el) return null;
+    const rowEl = el.closest<HTMLElement>('[data-dnd-kind]');
+    if (rowEl) {
+      const kind = rowEl.dataset.dndKind as 'session' | 'folder';
+      const id = Number(rowEl.dataset.dndId);
+      return slotForRow(rowEl.getBoundingClientRect(), y, kind, id);
     }
-    // Always preventDefault so the browser keeps treating us as a valid
-    // drop target. The full-payload validity check happens at drop time.
-    e.preventDefault();
-    e.stopPropagation();
-    e.dataTransfer.dropEffect = 'move';
-    setDragTargetIfChanged(slot);
+    if (el.closest('[data-dnd-root]')) return { kind: 'into-root' };
+    return null;
   }
 
-  async function handleDrop(e: React.DragEvent, slot: DropSlot) {
-    e.preventDefault();
-    e.stopPropagation();
-    const raw = e.dataTransfer.getData('application/json');
-    dragSourceRef.current = null;
-    setDrag(null);
-    setDragTarget(null);
-    if (!raw) return;
-    let payload: { kind: 'session' | 'folder'; id: number };
-    try { payload = JSON.parse(raw); } catch { return; }
+  /** Can't drop a folder into itself (either as a parent or as its own
+   *  sibling-edge). before/after-folder on self is a no-op drop, but we
+   *  still reject to avoid a confusing indicator line. Deeper cycles
+   *  (into a descendant) are rejected by the backend at drop time. */
+  function slotRejected(slot: DropSlot): boolean {
+    const src = dragSourceRef.current;
+    if (!src || src.kind !== 'folder') return false;
+    return (
+      (slot.kind === 'into-folder' || slot.kind === 'before-folder' || slot.kind === 'after-folder')
+      && slot.folderId === src.id
+    );
+  }
 
+  function handlePointerDown(
+    e: React.PointerEvent,
+    kind: 'session' | 'folder',
+    id: number,
+  ) {
+    // Buttons inside a row (delete) are clicks, never drag handles.
+    if ((e.target as HTMLElement).closest('button')) return;
+    beginPointerDrag(e, {
+      onDragStart: () => {
+        dragSourceRef.current = { kind, id };
+        setDrag({ kind, id });
+      },
+      onDragMove: (x, y) => {
+        const slot = slotAtPoint(x, y);
+        setDragTargetIfChanged(slot && !slotRejected(slot) ? slot : null);
+      },
+      onDrop: (x, y) => {
+        const slot = slotAtPoint(x, y);
+        if (slot && !slotRejected(slot)) void performDrop({ kind, id }, slot);
+      },
+      onEnd: () => {
+        dragSourceRef.current = null;
+        dragTargetRef.current = null;
+        setDrag(null);
+        setDragTarget(null);
+      },
+      scrollContainer: () => treeRef.current,
+      axis: 'y',
+    });
+  }
+
+  async function performDrop(
+    payload: { kind: 'session' | 'folder'; id: number },
+    slot: DropSlot,
+  ) {
     try {
       if (payload.kind === 'session') {
         await dropSession(payload.id, slot);
@@ -783,18 +786,14 @@ export function SessionsSidebar() {
   // itself is hoisted to module scope (below SessionsSidebar) so its
   // function identity stays stable across renders — defining it inline
   // would cause React to unmount + remount the entire tree on every
-  // setState (e.g. dragover → setDragTarget), which aborts in-flight
-  // HTML5 drags by ripping the source DOM out from under the browser.
+  // setState (e.g. pointermove → setDragTarget), losing scroll position
+  // and DOM state mid-drag.
   const nodeViewCtx: NodeViewCtx = {
     expanded,
     drag,
     dragTarget,
     selectedId,
-    handleDragStart,
-    handleDragEnd,
-    handleDragOver,
-    handleDrop,
-    slotForRow,
+    handlePointerDown,
     toggleFolder,
     openFolderMenu,
     openSessionMenu,
@@ -851,18 +850,17 @@ export function SessionsSidebar() {
       </div>
 
       {/* Tree — the whole container is a drop zone for "move to root".
-          Individual rows have their own onDragOver that stops propagation
-          for folder drops, so this only fires when the user hovers open
-          whitespace or a root-level row while dragging. */}
+          slotAtPoint resolves rows first, so this only matches when the
+          user hovers open whitespace while dragging. */}
       <div
+        ref={treeRef}
+        data-dnd-root
         className={`flex-1 min-h-0 overflow-auto py-1 transition-colors ${
           drag && dragTarget?.kind === 'into-root' ? 'bg-accent/10 outline outline-1 outline-accent/40 -outline-offset-1' : ''
         }`}
         role="tree"
         aria-label="Sessions"
         onContextMenu={(e) => { if (e.target === e.currentTarget) openFolderMenu(e, null); }}
-        onDragOver={(e) => handleDragOver(e, { kind: 'into-root' })}
-        onDrop={(e) => handleDrop(e, { kind: 'into-root' })}
       >
         {empty ? (
           <EmptyState

--- a/ui/components/tabs-shell.tsx
+++ b/ui/components/tabs-shell.tsx
@@ -1,27 +1,79 @@
 'use client';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { FolderTree, Network, Terminal, X } from 'lucide-react';
 import { useTabs } from '@/lib/tabs-store';
+import { beginPointerDrag } from '@/lib/pointer-drag';
 import { MdiArea } from './mdi-area';
 import { ViewModeToolbar } from './view-mode-toolbar';
 import { StatusDot } from './status-dot';
 
+type DropTarget = { index: number; side: 'left' | 'right' };
+
 export function TabsShell() {
   const { tabs, activeId, setActive, close, reorder } = useTabs();
 
-  // Drag-reorder state. Both only change on drag start/end and when the
-  // insertion point crosses a tab midpoint — not once per dragover tick.
+  // Pointer-event drag-reorder (NOT HTML5 DnD — WebKitGTK's native drag can
+  // hold the pointer grab forever and freeze the app on Linux, see #109).
+  // Both states only change on drag start/end and when the insertion point
+  // crosses a tab midpoint — not once per pointermove tick.
   const [dragFromIndex, setDragFromIndex] = useState<number | null>(null);
-  const [dropTarget, setDropTarget] = useState<{ index: number; side: 'left' | 'right' } | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
 
   const clearDrag = () => {
     setDragFromIndex(null);
     setDropTarget(null);
   };
 
+  /** Tab-strip drop target under the pointer, by hit-testing tab rects.
+   *  Past either end of the strip snaps to the first/last edge. */
+  const dropTargetAt = (x: number): DropTarget | null => {
+    const strip = stripRef.current;
+    if (!strip) return null;
+    const els = Array.from(strip.querySelectorAll<HTMLElement>('[data-tab-index]'));
+    if (els.length === 0) return null;
+    for (const el of els) {
+      const rect = el.getBoundingClientRect();
+      if (x < rect.left || x >= rect.right) continue;
+      const index = Number(el.dataset.tabIndex);
+      return { index, side: x < rect.left + rect.width / 2 ? 'left' : 'right' };
+    }
+    if (x < els[0].getBoundingClientRect().left) return { index: 0, side: 'left' };
+    if (x >= els[els.length - 1].getBoundingClientRect().right) {
+      return { index: els.length - 1, side: 'right' };
+    }
+    return null;
+  };
+
+  const startTabDrag = (e: React.PointerEvent, fromIndex: number) => {
+    // Buttons inside the tab (close, panes) are clicks, never drag handles.
+    if ((e.target as HTMLElement).closest('button')) return;
+    beginPointerDrag(e, {
+      onDragStart: () => setDragFromIndex(fromIndex),
+      onDragMove: (x) => {
+        const next = dropTargetAt(x);
+        // Dropping onto the source tab is a no-op (see store.reorder).
+        // Suppress the drop indicator there so users don't think a
+        // move will happen when it won't.
+        const shown = next && next.index === fromIndex ? null : next;
+        setDropTarget((prev) =>
+          prev?.index === shown?.index && prev?.side === shown?.side ? prev : shown,
+        );
+      },
+      onDrop: (x) => {
+        const target = dropTargetAt(x);
+        if (!target) return;
+        reorder(fromIndex, target.side === 'left' ? target.index : target.index + 1);
+      },
+      onEnd: clearDrag,
+      scrollContainer: () => stripRef.current,
+      axis: 'x',
+    });
+  };
+
   return (
     <div className="h-full flex flex-col min-h-0">
-      <div className="h-8 border-b border-border bg-surface flex items-stretch overflow-x-auto">
+      <div ref={stripRef} className="h-8 border-b border-border bg-surface flex items-stretch overflow-x-auto">
         {tabs.length === 0 && (
           <div className="self-center px-3 text-muted text-xs flex items-center gap-2">
             <Terminal size={12} />
@@ -36,49 +88,8 @@ export function TabsShell() {
           return (
             <div
               key={t.tabId}
-              draggable
-              onDragStart={(e) => {
-                setDragFromIndex(index);
-                e.dataTransfer.effectAllowed = 'move';
-                // Blank drag image — our opacity + accent bar carry the feedback.
-                // 1x1 transparent GIF avoids the OS "ghost tab" that looks janky
-                // over the existing visual cues.
-                const img = new Image();
-                img.src =
-                  'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-                e.dataTransfer.setDragImage(img, 0, 0);
-              }}
-              onDragOver={(e) => {
-                if (dragFromIndex === null) return;
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                // Dropping onto the source tab is a no-op (see store.reorder).
-                // Suppress the drop indicator there so users don't think a
-                // move will happen when it won't.
-                if (dragFromIndex === index) return;
-                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-                const side = e.clientX < rect.left + rect.width / 2 ? 'left' : 'right';
-                setDropTarget((prev) =>
-                  prev?.index === index && prev.side === side ? prev : { index, side },
-                );
-              }}
-              onDragLeave={(e) => {
-                // Only clear if we're leaving this tab, not entering a child.
-                const related = e.relatedTarget as Node | null;
-                if (related && (e.currentTarget as HTMLDivElement).contains(related)) return;
-                setDropTarget((prev) => (prev?.index === index ? null : prev));
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                if (dragFromIndex === null) return;
-                const from = dragFromIndex;
-                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-                const side = e.clientX < rect.left + rect.width / 2 ? 'left' : 'right';
-                const to = side === 'left' ? index : index + 1;
-                reorder(from, to);
-                clearDrag();
-              }}
-              onDragEnd={clearDrag}
+              data-tab-index={index}
+              onPointerDown={(e) => startTabDrag(e, index)}
               onClick={() => setActive(t.tabId)}
               onMouseDown={(e) => { if (e.button === 1) { e.preventDefault(); close(t.tabId); } }}
               className={`group relative flex items-center gap-2 px-3 cursor-grab active:cursor-grabbing select-none border-r border-border ${
@@ -113,7 +124,6 @@ export function TabsShell() {
               {(t.session.session_kind === 'ssh' || t.session.session_kind === 'wsl') && (
                 <button
                   type="button"
-                  draggable={false}
                   onClick={(e) => {
                     e.stopPropagation();
                     useTabs.getState().setSftpOpen(t.tabId, !t.sftpOpen);
@@ -129,7 +139,6 @@ export function TabsShell() {
               {t.session.session_kind === 'ssh' && (
                 <button
                   type="button"
-                  draggable={false}
                   onClick={(e) => {
                     e.stopPropagation();
                     useTabs.getState().setForwardsOpen(t.tabId, !t.forwardsOpen);
@@ -144,7 +153,6 @@ export function TabsShell() {
               )}
               <button
                 type="button"
-                draggable={false}
                 aria-label="Close tab"
                 onClick={(e) => { e.stopPropagation(); close(t.tabId); }}
                 className={`icon-btn w-5 h-5 ${on ? '' : 'opacity-0 group-hover:opacity-100'}`}

--- a/ui/components/tabs-shell.tsx
+++ b/ui/components/tabs-shell.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FolderTree, Network, Terminal, X } from 'lucide-react';
 import { useTabs } from '@/lib/tabs-store';
 import { beginPointerDrag } from '@/lib/pointer-drag';
@@ -15,55 +15,81 @@ export function TabsShell() {
   // Pointer-event drag-reorder (NOT HTML5 DnD — WebKitGTK's native drag can
   // hold the pointer grab forever and freeze the app on Linux, see #109).
   // Both states only change on drag start/end and when the insertion point
-  // crosses a tab midpoint — not once per pointermove tick.
-  const [dragFromIndex, setDragFromIndex] = useState<number | null>(null);
+  // crosses a tab midpoint — not once per pointermove tick. The dragged tab
+  // is tracked by stable tabId, not index — a chorded middle-click can
+  // close a tab mid-drag and shift every index.
+  const [dragTabId, setDragTabId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   const stripRef = useRef<HTMLDivElement>(null);
 
+  // Tear down an in-flight drag if this component ever unmounts — the
+  // helper's window listeners would otherwise outlive it.
+  const dragCancelRef = useRef<(() => void) | undefined>(undefined);
+  useEffect(() => () => dragCancelRef.current?.(), []);
+
   const clearDrag = () => {
-    setDragFromIndex(null);
+    setDragTabId(null);
     setDropTarget(null);
   };
 
+  /** Pointer must stay within this band above/below the strip for a drop
+   *  target to resolve — releasing further away aborts the drag, matching
+   *  the old HTML5 drop-outside-is-a-no-op behavior. */
+  const STRIP_Y_TOLERANCE_PX = 24;
+
+  /** Live index of a tab — resolved at use time, never captured, so a tab
+   *  closing mid-drag can't make us reorder the wrong one. */
+  const tabIndexOf = (id: string) =>
+    useTabs.getState().tabs.findIndex((tb) => tb.tabId === id);
+
   /** Tab-strip drop target under the pointer, by hit-testing tab rects.
-   *  Past either end of the strip snaps to the first/last edge. */
-  const dropTargetAt = (x: number): DropTarget | null => {
+   *  Past either horizontal end of the strip snaps to the first/last edge;
+   *  vertically outside the strip (plus tolerance) is no target at all. */
+  const dropTargetAt = (x: number, y: number): DropTarget | null => {
     const strip = stripRef.current;
     if (!strip) return null;
+    const stripRect = strip.getBoundingClientRect();
+    if (
+      y < stripRect.top - STRIP_Y_TOLERANCE_PX ||
+      y > stripRect.bottom + STRIP_Y_TOLERANCE_PX
+    ) {
+      return null;
+    }
     const els = Array.from(strip.querySelectorAll<HTMLElement>('[data-tab-index]'));
     if (els.length === 0) return null;
+    let firstLeft = Infinity;
+    let lastRight = -Infinity;
     for (const el of els) {
       const rect = el.getBoundingClientRect();
+      firstLeft = Math.min(firstLeft, rect.left);
+      lastRight = Math.max(lastRight, rect.right);
       if (x < rect.left || x >= rect.right) continue;
       const index = Number(el.dataset.tabIndex);
       return { index, side: x < rect.left + rect.width / 2 ? 'left' : 'right' };
     }
-    if (x < els[0].getBoundingClientRect().left) return { index: 0, side: 'left' };
-    if (x >= els[els.length - 1].getBoundingClientRect().right) {
-      return { index: els.length - 1, side: 'right' };
-    }
+    if (x < firstLeft) return { index: 0, side: 'left' };
+    if (x >= lastRight) return { index: els.length - 1, side: 'right' };
     return null;
   };
 
-  const startTabDrag = (e: React.PointerEvent, fromIndex: number) => {
-    // Buttons inside the tab (close, panes) are clicks, never drag handles.
-    if ((e.target as HTMLElement).closest('button')) return;
-    beginPointerDrag(e, {
-      onDragStart: () => setDragFromIndex(fromIndex),
-      onDragMove: (x) => {
-        const next = dropTargetAt(x);
+  const startTabDrag = (e: React.PointerEvent, tabId: string) => {
+    dragCancelRef.current = beginPointerDrag(e, {
+      onDragStart: () => setDragTabId(tabId),
+      onDragMove: (x, y) => {
+        const next = dropTargetAt(x, y);
         // Dropping onto the source tab is a no-op (see store.reorder).
         // Suppress the drop indicator there so users don't think a
         // move will happen when it won't.
-        const shown = next && next.index === fromIndex ? null : next;
+        const shown = next && next.index === tabIndexOf(tabId) ? null : next;
         setDropTarget((prev) =>
           prev?.index === shown?.index && prev?.side === shown?.side ? prev : shown,
         );
       },
-      onDrop: (x) => {
-        const target = dropTargetAt(x);
-        if (!target) return;
-        reorder(fromIndex, target.side === 'left' ? target.index : target.index + 1);
+      onDrop: (x, y) => {
+        const from = tabIndexOf(tabId);
+        const target = dropTargetAt(x, y);
+        if (from < 0 || !target) return;
+        reorder(from, target.side === 'left' ? target.index : target.index + 1);
       },
       onEnd: clearDrag,
       scrollContainer: () => stripRef.current,
@@ -82,14 +108,14 @@ export function TabsShell() {
         )}
         {tabs.map((t, index) => {
           const on = t.tabId === activeId;
-          const dragging = dragFromIndex === index;
+          const dragging = dragTabId === t.tabId;
           const showLeftIndicator = dropTarget?.index === index && dropTarget.side === 'left';
           const showRightIndicator = dropTarget?.index === index && dropTarget.side === 'right';
           return (
             <div
               key={t.tabId}
               data-tab-index={index}
-              onPointerDown={(e) => startTabDrag(e, index)}
+              onPointerDown={(e) => startTabDrag(e, t.tabId)}
               onClick={() => setActive(t.tabId)}
               onMouseDown={(e) => { if (e.button === 1) { e.preventDefault(); close(t.tabId); } }}
               className={`group relative flex items-center gap-2 px-3 cursor-grab active:cursor-grabbing select-none border-r border-border ${

--- a/ui/lib/pointer-drag.ts
+++ b/ui/lib/pointer-drag.ts
@@ -1,0 +1,145 @@
+/**
+ * Pointer-event drag helper — replaces HTML5 drag-and-drop for in-app
+ * reordering (tab bar, sessions tree).
+ *
+ * Why not HTML5 DnD: WebKitGTK's native drag implementation can take the
+ * pointer grab and never release it (drag-end never fires), hard-freezing
+ * the whole app on Linux — see issue #109 and
+ * https://bugs.webkit.org/show_bug.cgi?id=32840. Pointer events run
+ * entirely inside the webview's normal event loop, so they behave
+ * identically on Windows, macOS, and Linux.
+ *
+ * Call from a `pointerdown` handler. The drag only starts once the pointer
+ * moves past a small threshold, so plain clicks (and double-clicks) on the
+ * same element keep working. Listeners go on `window` rather than using
+ * pointer capture so the drag survives React re-rendering the source row
+ * mid-drag.
+ */
+
+const DRAG_THRESHOLD_PX = 4;
+/** Distance from the scroll container's edge where auto-scroll kicks in. */
+const AUTOSCROLL_EDGE_PX = 28;
+/** Auto-scroll speed in px per animation frame. */
+const AUTOSCROLL_SPEED_PX = 10;
+
+export interface PointerDragHandlers {
+  /** Pointer crossed the drag threshold — show drag visuals. */
+  onDragStart(): void;
+  /** Pointer moved while dragging (also fired during auto-scroll ticks). */
+  onDragMove(x: number, y: number): void;
+  /** Pointer released while dragging. Not called for cancelled drags. */
+  onDrop(x: number, y: number): void;
+  /**
+   * Drag interaction finished for any reason — drop, Escape, pointer
+   * cancel, or a plain click that never crossed the threshold. Clear all
+   * drag state here.
+   */
+  onEnd(): void;
+  /** Container to auto-scroll when the pointer nears its edges. */
+  scrollContainer?: () => HTMLElement | null;
+  /** Scroll axis for auto-scroll. Defaults to 'y'. */
+  axis?: 'x' | 'y';
+}
+
+/**
+ * After a real drag, the browser still dispatches a `click` on the common
+ * ancestor of pointerdown/pointerup targets. Swallow exactly that one click
+ * so drops don't also activate tabs / toggle folders. The listener removes
+ * itself on the next macrotask if no click fired (e.g. drop outside).
+ */
+function suppressNextClick(): void {
+  const squelch = (ev: MouseEvent) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+  };
+  window.addEventListener('click', squelch, { capture: true });
+  window.setTimeout(
+    () => window.removeEventListener('click', squelch, { capture: true }),
+    0,
+  );
+}
+
+export function beginPointerDrag(
+  e: React.PointerEvent,
+  handlers: PointerDragHandlers,
+): void {
+  // Left button only; touch is left to native scrolling.
+  if (e.button !== 0 || e.pointerType === 'touch') return;
+
+  const pointerId = e.pointerId;
+  const startX = e.clientX;
+  const startY = e.clientY;
+  let dragging = false;
+  let lastX = startX;
+  let lastY = startY;
+  let raf = 0;
+  const prevUserSelect = document.body.style.userSelect;
+
+  const scrollTick = () => {
+    raf = requestAnimationFrame(scrollTick);
+    const container = handlers.scrollContainer?.();
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const horizontal = handlers.axis === 'x';
+    const pos = horizontal ? lastX : lastY;
+    const lo = (horizontal ? rect.left : rect.top) + AUTOSCROLL_EDGE_PX;
+    const hi = (horizontal ? rect.right : rect.bottom) - AUTOSCROLL_EDGE_PX;
+    const delta = pos < lo ? -AUTOSCROLL_SPEED_PX : pos > hi ? AUTOSCROLL_SPEED_PX : 0;
+    if (delta === 0) return;
+    if (horizontal) container.scrollLeft += delta;
+    else container.scrollTop += delta;
+    // Content shifted under a stationary pointer — recompute the target.
+    handlers.onDragMove(lastX, lastY);
+  };
+
+  const finish = (drop: boolean, ev?: PointerEvent) => {
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+    window.removeEventListener('pointercancel', onCancel);
+    window.removeEventListener('keydown', onKey, true);
+    if (raf) cancelAnimationFrame(raf);
+    if (dragging) {
+      document.body.style.userSelect = prevUserSelect;
+      suppressNextClick();
+      if (drop && ev) handlers.onDrop(ev.clientX, ev.clientY);
+    }
+    handlers.onEnd();
+  };
+
+  const onMove = (ev: PointerEvent) => {
+    if (ev.pointerId !== pointerId) return;
+    lastX = ev.clientX;
+    lastY = ev.clientY;
+    if (!dragging) {
+      if (
+        Math.abs(ev.clientX - startX) < DRAG_THRESHOLD_PX &&
+        Math.abs(ev.clientY - startY) < DRAG_THRESHOLD_PX
+      ) {
+        return;
+      }
+      dragging = true;
+      document.body.style.userSelect = 'none';
+      handlers.onDragStart();
+      if (handlers.scrollContainer) raf = requestAnimationFrame(scrollTick);
+    }
+    handlers.onDragMove(ev.clientX, ev.clientY);
+  };
+
+  const onUp = (ev: PointerEvent) => {
+    if (ev.pointerId === pointerId) finish(true, ev);
+  };
+  const onCancel = (ev: PointerEvent) => {
+    if (ev.pointerId === pointerId) finish(false);
+  };
+  const onKey = (ev: KeyboardEvent) => {
+    if (ev.key === 'Escape' && dragging) {
+      ev.stopPropagation();
+      finish(false);
+    }
+  };
+
+  window.addEventListener('pointermove', onMove);
+  window.addEventListener('pointerup', onUp);
+  window.addEventListener('pointercancel', onCancel);
+  window.addEventListener('keydown', onKey, true);
+}

--- a/ui/lib/pointer-drag.ts
+++ b/ui/lib/pointer-drag.ts
@@ -13,7 +13,14 @@
  * moves past a small threshold, so plain clicks (and double-clicks) on the
  * same element keep working. Listeners go on `window` rather than using
  * pointer capture so the drag survives React re-rendering the source row
- * mid-drag.
+ * mid-drag. `onDragMove` is coalesced to one call per animation frame —
+ * consumers do forced-layout hit-testing there, and high-rate mice deliver
+ * several pointermoves per frame.
+ *
+ * Returns a cancel function (or undefined when the gesture can't start a
+ * drag); components whose drag surface can unmount mid-drag must call it
+ * from their unmount cleanup, or the window listeners outlive the
+ * component with stale closures.
  */
 
 const DRAG_THRESHOLD_PX = 4;
@@ -25,14 +32,15 @@ const AUTOSCROLL_SPEED_PX = 10;
 export interface PointerDragHandlers {
   /** Pointer crossed the drag threshold — show drag visuals. */
   onDragStart(): void;
-  /** Pointer moved while dragging (also fired during auto-scroll ticks). */
+  /** Pointer moved while dragging (also fired during auto-scroll ticks).
+   *  Coalesced to at most one call per animation frame. */
   onDragMove(x: number, y: number): void;
   /** Pointer released while dragging. Not called for cancelled drags. */
   onDrop(x: number, y: number): void;
   /**
    * Drag interaction finished for any reason — drop, Escape, pointer
-   * cancel, or a plain click that never crossed the threshold. Clear all
-   * drag state here.
+   * cancel, lost button, or a plain click that never crossed the
+   * threshold. Clear all drag state here.
    */
   onEnd(): void;
   /** Container to auto-scroll when the pointer nears its edges. */
@@ -42,48 +50,68 @@ export interface PointerDragHandlers {
 }
 
 /**
- * After a real drag, the browser still dispatches a `click` on the common
- * ancestor of pointerdown/pointerup targets. Swallow exactly that one click
- * so drops don't also activate tabs / toggle folders. The listener removes
- * itself on the next macrotask if no click fired (e.g. drop outside).
+ * After a real drag (or an Escape-cancelled one whose button is released
+ * later), the browser still dispatches a `click` on the common ancestor of
+ * the pointerdown/pointerup targets. Swallow exactly that one click so a
+ * drop or cancel never also activates a tab / toggles a folder.
+ *
+ * Disarms on the first click it swallows OR on the next `pointerdown`:
+ * every other click is necessarily preceded by its own pointerdown, so the
+ * squelch can never eat an unrelated gesture's click — and unlike a
+ * timeout, this doesn't race a busy main thread delaying the click.
  */
 function suppressNextClick(): void {
   const squelch = (ev: MouseEvent) => {
     ev.stopPropagation();
     ev.preventDefault();
+    disarm();
+  };
+  const disarm = () => {
+    window.removeEventListener('click', squelch, { capture: true });
+    window.removeEventListener('pointerdown', disarm, { capture: true });
   };
   window.addEventListener('click', squelch, { capture: true });
-  window.setTimeout(
-    () => window.removeEventListener('click', squelch, { capture: true }),
-    0,
-  );
+  window.addEventListener('pointerdown', disarm, { capture: true });
 }
 
 export function beginPointerDrag(
   e: React.PointerEvent,
   handlers: PointerDragHandlers,
-): void {
-  // Left button only; touch is left to native scrolling.
-  if (e.button !== 0 || e.pointerType === 'touch') return;
+): (() => void) | undefined {
+  // Left button only; touch is left to native scrolling. Buttons inside
+  // the pressed element (close, delete, panes) are clicks, never drag
+  // handles.
+  if (e.button !== 0 || e.pointerType === 'touch') return undefined;
+  if ((e.target as HTMLElement).closest('button')) return undefined;
 
   const pointerId = e.pointerId;
   const startX = e.clientX;
   const startY = e.clientY;
   let dragging = false;
+  let done = false;
   let lastX = startX;
   let lastY = startY;
-  let raf = 0;
+  let scrollRaf = 0;
+  let moveRaf = 0;
+  // Cached at drag start: the container's own rect can't change during a
+  // drag (only its scroll offset does), and reading it per frame forces a
+  // reflow whenever something else (e.g. xterm output) dirtied layout.
+  let scrollRect: DOMRect | null = null;
   const prevUserSelect = document.body.style.userSelect;
 
+  const flushMove = () => {
+    moveRaf = 0;
+    handlers.onDragMove(lastX, lastY);
+  };
+
   const scrollTick = () => {
-    raf = requestAnimationFrame(scrollTick);
+    scrollRaf = requestAnimationFrame(scrollTick);
     const container = handlers.scrollContainer?.();
-    if (!container) return;
-    const rect = container.getBoundingClientRect();
+    if (!container || !scrollRect) return;
     const horizontal = handlers.axis === 'x';
     const pos = horizontal ? lastX : lastY;
-    const lo = (horizontal ? rect.left : rect.top) + AUTOSCROLL_EDGE_PX;
-    const hi = (horizontal ? rect.right : rect.bottom) - AUTOSCROLL_EDGE_PX;
+    const lo = (horizontal ? scrollRect.left : scrollRect.top) + AUTOSCROLL_EDGE_PX;
+    const hi = (horizontal ? scrollRect.right : scrollRect.bottom) - AUTOSCROLL_EDGE_PX;
     const delta = pos < lo ? -AUTOSCROLL_SPEED_PX : pos > hi ? AUTOSCROLL_SPEED_PX : 0;
     if (delta === 0) return;
     if (horizontal) container.scrollLeft += delta;
@@ -92,22 +120,38 @@ export function beginPointerDrag(
     handlers.onDragMove(lastX, lastY);
   };
 
-  const finish = (drop: boolean, ev?: PointerEvent) => {
+  const teardown = () => {
+    done = true;
     window.removeEventListener('pointermove', onMove);
     window.removeEventListener('pointerup', onUp);
     window.removeEventListener('pointercancel', onCancel);
     window.removeEventListener('keydown', onKey, true);
-    if (raf) cancelAnimationFrame(raf);
-    if (dragging) {
-      document.body.style.userSelect = prevUserSelect;
-      suppressNextClick();
-      if (drop && ev) handlers.onDrop(ev.clientX, ev.clientY);
-    }
+    if (scrollRaf) cancelAnimationFrame(scrollRaf);
+    if (moveRaf) cancelAnimationFrame(moveRaf);
+    if (dragging) document.body.style.userSelect = prevUserSelect;
+  };
+
+  /** Abort without dropping: Escape, lost button, pointercancel, or the
+   *  owning component unmounting. Safe to call repeatedly. */
+  const cancel = () => {
+    if (done) return;
+    teardown();
+    // The button may still be held (Escape mid-drag): its eventual release
+    // fires a click with no intervening pointerdown, which the squelch
+    // catches; if no such click ever comes, the next pointerdown disarms.
+    if (dragging) suppressNextClick();
     handlers.onEnd();
   };
 
   const onMove = (ev: PointerEvent) => {
     if (ev.pointerId !== pointerId) return;
+    // A pointerup lost outside the window leaves no button held; without
+    // this check the drag would stay armed and the user's NEXT click would
+    // deliver the drop.
+    if (ev.buttons === 0) {
+      cancel();
+      return;
+    }
     lastX = ev.clientX;
     lastY = ev.clientY;
     if (!dragging) {
@@ -120,21 +164,32 @@ export function beginPointerDrag(
       dragging = true;
       document.body.style.userSelect = 'none';
       handlers.onDragStart();
-      if (handlers.scrollContainer) raf = requestAnimationFrame(scrollTick);
+      if (handlers.scrollContainer) {
+        scrollRect = handlers.scrollContainer()?.getBoundingClientRect() ?? null;
+        scrollRaf = requestAnimationFrame(scrollTick);
+      }
     }
-    handlers.onDragMove(ev.clientX, ev.clientY);
+    if (!moveRaf) moveRaf = requestAnimationFrame(flushMove);
   };
 
   const onUp = (ev: PointerEvent) => {
-    if (ev.pointerId === pointerId) finish(true, ev);
+    if (ev.pointerId !== pointerId || done) return;
+    teardown();
+    if (dragging) {
+      suppressNextClick();
+      handlers.onDrop(ev.clientX, ev.clientY);
+    }
+    handlers.onEnd();
   };
+
   const onCancel = (ev: PointerEvent) => {
-    if (ev.pointerId === pointerId) finish(false);
+    if (ev.pointerId === pointerId) cancel();
   };
+
   const onKey = (ev: KeyboardEvent) => {
     if (ev.key === 'Escape' && dragging) {
       ev.stopPropagation();
-      finish(false);
+      cancel();
     }
   };
 
@@ -142,4 +197,6 @@ export function beginPointerDrag(
   window.addEventListener('pointerup', onUp);
   window.addEventListener('pointercancel', onCancel);
   window.addEventListener('keydown', onKey, true);
+
+  return cancel;
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.7.3",
+  "version": "1.7.4",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
## Summary

Closes #109.

Re-arranging tabs with live SSH sessions could hard-freeze the app on Linux. The tab bar (and sessions sidebar) used native HTML5 drag-and-drop, which on WebKitGTK can take the pointer grab and never release it — drag-end never fires and the window stops responding ([WebKit bug 32840](https://bugs.webkit.org/show_bug.cgi?id=32840); related Tauri reports: tauri-apps/tauri#6695, tauri-apps/tauri#9725, tauri-apps/tauri#12052).

## Changes

- **New `ui/lib/pointer-drag.ts`** — shared pointer-event drag helper: drag starts only past a 4px threshold (plain clicks and double-clicks keep working), listeners live on `window` so the drag survives mid-drag React re-renders, `Escape` cancels, the post-drag `click` is swallowed so a drop never also activates a tab / toggles a folder, and the container auto-scrolls near its edges (HTML5 DnD parity). `onDragMove` is rAF-coalesced and the helper returns a cancel handle for unmount teardown.
- **`tabs-shell.tsx`** — tab reorder now hit-tests tab rects under the pointer (with a y-tolerance band, so releasing away from the strip aborts). Dragged tab tracked by stable `tabId`. Same midpoint left/right drop semantics, same indicator visuals, same `store.reorder` call.
- **`sessions-sidebar.tsx`** — tree DnD resolves the drop slot via `elementFromPoint` + `data-dnd-*` row attributes. All `DropSlot` semantics (50/50 session split, 25/50/25 folder split, into-root, self-drop rejection — now including session self-drops) and backend calls are unchanged. Drops read drop-time data through live refs.
- **`main-shell.tsx`** — window-level `dragstart` guard blocks ALL in-page native drag initiation (anchors/selected text are natively draggable in WebKit), closing the whole #109 bug class. OS file drops into the SFTP pane are unaffected — external drags never fire an in-page `dragstart`.
- **`mdi-area.tsx`** — memoized so drag-indicator re-renders never touch the terminal area.
- **`xserver/mod.rs`** — cfg-gate the Windows-only `VCXSRV_INSTALLER_URL` const to clear the `dead_code` warning on non-Windows `cargo check`.
- Version 1.7.4 + release notes (also re-aligns `package.json`/`tauri.conf.json`, which were left at 1.7.1 when the workspace went to 1.7.2).

## Review

A 7-angle review pass (correctness ×3, reuse, simplification, efficiency, altitude) with adversarial verification ran against the first commit; all 10 surviving findings are fixed in the second commit — drag-abort gestures, Escape click-leak, lost-pointerup phantom drops, unmount teardown, stale-snapshot drops, self-drop no-ops, tabId tracking, rAF coalescing, and helper API cleanup.

## Cross-platform impact

Pointer events run entirely inside the webview's normal event loop and behave identically on Windows, macOS, and Linux — no WebKitGTK/OS drag machinery involved. UX is unchanged on all platforms.

## Testing

- `cargo check` — clean, no warnings
- `ui npm run lint` / `typecheck` / `build` — pass; remaining lint warnings are pre-existing on `main` (verified by stash-diff)