### PR TITLE
Harden credential manager from review findings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/docs/release-notes/v1.8.1.md
+++ b/docs/release-notes/v1.8.1.md
@@ -1,0 +1,31 @@
+# ezTerm v1.8.1
+
+SSH keys, key passphrases, and passwords are now fully manageable: a new **Credentials** manager lists everything in the vault and supports rename, secret rotation, and delete — previously credentials could only be *added*, from inside the session editor. v1.8.1 also folds in the post-merge review hardening pass on that feature (v1.8.0 was never tagged; this release carries both).
+
+## What changed
+
+### Credential manager — feature (#111, #112)
+
+- **`ui/components/credentials-dialog.tsx`** (new) — a vault credential manager grouped by kind (SSH keys, key passphrases, passwords). Each row shows the label, creation date, and which sessions use the credential (names on hover), with rename, replace-secret, and delete actions plus per-group add.
+- **Delete warns about usage** — deleting a credential that sessions still reference lists those sessions in the confirm dialog; they'll need a new credential before their next connect (the schema's `ON DELETE SET NULL` behavior is unchanged, just no longer silent).
+- **Entry points** — right-click the sidebar background → **Credentials…**, or the manage button next to any credential picker in the session editor.
+- **Backend** — new `credential_list_detailed` (adds `created_at` + per-credential session usage) and `credential_update` Tauri commands; renames and secret rotations apply to every session referencing the credential, with no re-entry of unchanged fields.
+
+### Review hardening — fixes (#113)
+
+- **Dangling credential references can't be saved** — every credential picker now re-syncs and clamps its selection whenever any credentials manager mutates the vault (a new in-app broadcast), so deleting a credential selected in a *sibling* picker no longer leads to a `FOREIGN KEY constraint failed` on session save. The sidebar also refreshes its session list when the manager closes.
+- **Nested-dialog key handling** — the manager swallows Ctrl/Cmd+Enter while open (it previously leaked through to the session editor's save-and-close), and Escape unwinds one layer at a time even mid-mutation instead of going dead app-wide.
+- **Renders as a true modal everywhere** — the dialog is portaled to `<body>`, fixing a clipped, non-modal render when opened from the auth-retry overlay (whose `backdrop-filter` re-anchored `fixed` descendants) and removing the implicit-form-submit hazard inside the session editor.
+- **Rotation can't revert a rename** — label and secret updates are independent in `credential_update` down to the SQL, so replacing a secret no longer echoes back a possibly-stale label.
+- **Plaintext zeroized on every path** — `credential_create`/`credential_update` wrap incoming secrets in `Zeroizing` immediately, closing a leak where a failed encrypt (e.g. vault auto-locked mid-operation) skipped the manual zeroize.
+- **Mutation correctness** — concurrent mutations from rapid Enter presses are dropped by a re-entrancy guard; a failed delete keeps the confirm dialog open instead of looking successful; Enter saves in the add/replace forms like it already did in the rename row.
+
+## Verify
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Licence
+
+**GPL v3** (version 3 only). See [LICENSE](../blob/main/LICENSE).

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -1,5 +1,5 @@
 use tauri::State;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::commands::require_unlocked;
 use crate::db::credentials::{self, CredentialDetail, CredentialMeta};
@@ -23,9 +23,12 @@ pub async fn credential_create(
     state: State<'_, AppState>,
     kind: String,
     label: String,
-    mut plaintext: String,
+    plaintext: String,
 ) -> Result<CredentialMeta> {
     require_unlocked(&state).await?;
+    // Wrap immediately so every return path — validation errors and a
+    // failed encrypt alike — zeroizes the secret on drop.
+    let plaintext = Zeroizing::new(plaintext);
     if !matches!(kind.as_str(), "password" | "private_key" | "key_passphrase") {
         return Err(AppError::Validation("invalid kind".into()));
     }
@@ -36,7 +39,6 @@ pub async fn credential_create(
         return Err(AppError::Validation("label too long".into()));
     }
     if plaintext.len() > MAX_PLAINTEXT_LEN {
-        plaintext.zeroize();
         return Err(AppError::Validation("secret too long".into()));
     }
 
@@ -45,7 +47,6 @@ pub async fn credential_create(
         let vault_state = state.vault.read().await;
         vault::encrypt_with(&vault_state, plaintext.as_bytes())?
     };
-    plaintext.zeroize();
 
     let id = credentials::insert(&state.db, &kind, label.trim(), &nonce, &ct).await?;
     state.sync.trigger();
@@ -64,40 +65,52 @@ pub async fn credential_list_detailed(
     credentials::list_detailed(&state.db).await
 }
 
-/// Rename a credential and optionally replace its secret. `plaintext` of
-/// `None` (or empty) keeps the existing ciphertext so a rename never
-/// requires re-entering the key/passphrase.
+/// Rename a credential and/or replace its secret. Each field is
+/// independent: `label: None` rotates the secret without touching the
+/// name (so a stale UI label can't silently revert a rename), and
+/// `plaintext: None` (or empty) renames without re-entering the secret.
 #[tauri::command]
 pub async fn credential_update(
     state: State<'_, AppState>,
     id: i64,
-    label: String,
+    label: Option<String>,
     plaintext: Option<String>,
 ) -> Result<()> {
     require_unlocked(&state).await?;
-    if label.trim().is_empty() {
-        return Err(AppError::Validation("label required".into()));
-    }
-    if label.len() > MAX_LABEL_LEN {
-        return Err(AppError::Validation("label too long".into()));
+    // Wrap immediately so every return path zeroizes the secret on drop.
+    let plaintext = plaintext.map(Zeroizing::new);
+
+    if let Some(l) = &label {
+        if l.trim().is_empty() {
+            return Err(AppError::Validation("label required".into()));
+        }
+        if l.len() > MAX_LABEL_LEN {
+            return Err(AppError::Validation("label too long".into()));
+        }
     }
 
-    match plaintext {
-        Some(mut pt) if !pt.is_empty() => {
+    let secret = match &plaintext {
+        Some(pt) if !pt.is_empty() => {
             if pt.len() > MAX_PLAINTEXT_LEN {
-                pt.zeroize();
                 return Err(AppError::Validation("secret too long".into()));
             }
             // Scope the vault read guard so it is dropped before the DB write.
-            let (nonce, ct) = {
-                let vault_state = state.vault.read().await;
-                vault::encrypt_with(&vault_state, pt.as_bytes())?
-            };
-            pt.zeroize();
-            credentials::update_secret(&state.db, id, label.trim(), &nonce, &ct).await?;
+            let vault_state = state.vault.read().await;
+            Some(vault::encrypt_with(&vault_state, pt.as_bytes())?)
         }
-        _ => credentials::update_label(&state.db, id, label.trim()).await?,
+        _ => None,
+    };
+    if label.is_none() && secret.is_none() {
+        return Err(AppError::Validation("nothing to update".into()));
     }
+
+    credentials::update(
+        &state.db,
+        id,
+        label.as_deref().map(str::trim),
+        secret.as_ref().map(|(n, c)| (n.as_slice(), c.as_slice())),
+    )
+    .await?;
     state.sync.trigger();
     Ok(())
 }

--- a/src-tauri/src/db/credentials.rs
+++ b/src-tauri/src/db/credentials.rs
@@ -116,34 +116,29 @@ pub(crate) async fn get(pool: &SqlitePool, id: i64) -> Result<CredentialRow> {
     .ok_or(crate::error::AppError::NotFound)
 }
 
-pub(crate) async fn update_label(pool: &SqlitePool, id: i64, label: &str) -> Result<()> {
-    let n = sqlx::query("UPDATE credentials SET label = ? WHERE id = ?")
-        .bind(label)
-        .bind(id)
-        .execute(pool)
-        .await?
-        .rows_affected();
-    if n == 0 {
-        return Err(crate::error::AppError::NotFound);
-    }
-    Ok(())
-}
-
-pub(crate) async fn update_secret(
+/// Update a credential's label and/or its secret independently; `None`
+/// keeps the existing column values (COALESCE against NULL binds).
+pub(crate) async fn update(
     pool: &SqlitePool,
     id: i64,
-    label: &str,
-    nonce: &[u8],
-    ciphertext: &[u8],
+    label: Option<&str>,
+    secret: Option<(&[u8], &[u8])>,
 ) -> Result<()> {
-    let n = sqlx::query("UPDATE credentials SET label = ?, nonce = ?, ciphertext = ? WHERE id = ?")
-        .bind(label)
-        .bind(nonce)
-        .bind(ciphertext)
-        .bind(id)
-        .execute(pool)
-        .await?
-        .rows_affected();
+    let (nonce, ciphertext) = match secret {
+        Some((n, c)) => (Some(n), Some(c)),
+        None => (None, None),
+    };
+    let n = sqlx::query(
+        "UPDATE credentials SET label = COALESCE(?, label), \
+         nonce = COALESCE(?, nonce), ciphertext = COALESCE(?, ciphertext) WHERE id = ?",
+    )
+    .bind(label)
+    .bind(nonce)
+    .bind(ciphertext)
+    .bind(id)
+    .execute(pool)
+    .await?
+    .rows_affected();
     if n == 0 {
         return Err(crate::error::AppError::NotFound);
     }
@@ -187,27 +182,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_label_and_secret() {
+    async fn update_label_and_secret_independently() {
         let p = pool().await;
         let id = insert(&p, "private_key", "old-name", &[0u8; 12], &[1, 2, 3])
             .await
             .unwrap();
 
-        update_label(&p, id, "new-name").await.unwrap();
+        // Rename only — secret untouched.
+        update(&p, id, Some("new-name"), None).await.unwrap();
         let detail = &list_detailed(&p).await.unwrap()[0];
         assert_eq!(detail.label, "new-name");
         assert!(!detail.created_at.is_empty());
+        assert_eq!(get(&p, id).await.unwrap().ciphertext, vec![1, 2, 3]);
 
-        update_secret(&p, id, "rotated", &[9u8; 12], &[4, 5, 6])
+        // Rotate only — label untouched.
+        update(&p, id, None, Some((&[9u8; 12], &[4, 5, 6])))
             .await
             .unwrap();
         let row = get(&p, id).await.unwrap();
         assert_eq!(row.nonce, vec![9u8; 12]);
         assert_eq!(row.ciphertext, vec![4, 5, 6]);
-        assert_eq!(list(&p).await.unwrap()[0].label, "rotated");
+        assert_eq!(list(&p).await.unwrap()[0].label, "new-name");
 
-        assert!(update_label(&p, 9999, "x").await.is_err());
-        assert!(update_secret(&p, 9999, "x", &[0u8; 12], &[1]).await.is_err());
+        // Both at once.
+        update(&p, id, Some("both"), Some((&[7u8; 12], &[8])))
+            .await
+            .unwrap();
+        assert_eq!(list(&p).await.unwrap()[0].label, "both");
+        assert_eq!(get(&p, id).await.unwrap().ciphertext, vec![8]);
+
+        assert!(update(&p, 9999, Some("x"), None).await.is_err());
+        assert!(update(&p, 9999, None, Some((&[0u8; 12], &[1]))).await.is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/components/credential-picker.tsx
+++ b/ui/components/credential-picker.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Eye, EyeOff, Plus, Settings2 } from 'lucide-react';
 import { api } from '@/lib/tauri';
+import { onCredentialsChanged } from '@/lib/credential-events';
 import type { CredentialKind, CredentialMeta } from '@/lib/types';
 import { CredentialsDialog } from './credentials-dialog';
 
@@ -27,24 +28,21 @@ export function CredentialPicker({ kind, value, onChange }: Props) {
   const [busy, setBusy] = useState(false);
   const [managing, setManaging] = useState(false);
 
-  async function reload() {
+  /** Fetch the list and clamp a dangling selection. The selected id can
+   *  go stale several ways — the manager deleted it (opened from this
+   *  picker OR a sibling picker, which edits all kinds), or the session
+   *  form was seeded from a row whose credential was deleted earlier —
+   *  so clamping lives here, on every sync, not in any one close path. */
+  const syncList = useCallback(async () => {
     const all = await api.credentialList();
     setList(all.filter((c) => c.kind === kind));
-    return all;
-  }
-
-  /** The manager can rename or delete anything, including the currently
-   *  selected credential — refresh the list and drop a dangling value. */
-  async function closeManager() {
-    setManaging(false);
-    const all = await reload();
     if (value !== null && !all.some((c) => c.id === value && c.kind === kind)) {
       onChange(null);
     }
-  }
+  }, [kind, value, onChange]);
 
   useEffect(() => {
-    reload();
+    syncList();
     setAdding(false);
     setLabel('');
     setSecret('');
@@ -52,6 +50,10 @@ export function CredentialPicker({ kind, value, onChange }: Props) {
     setErr(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind]);
+
+  // Stay in sync while any credentials manager is mutating the vault —
+  // the broadcast fires after every successful rename/rotate/add/delete.
+  useEffect(() => onCredentialsChanged(() => { void syncList(); }), [syncList]);
 
   async function create() {
     if (!label.trim() || !secret) {
@@ -66,7 +68,7 @@ export function CredentialPicker({ kind, value, onChange }: Props) {
       setLabel('');
       setShow(false);
       setAdding(false);
-      await reload();
+      await syncList();
       onChange(created.id);
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -110,7 +112,10 @@ export function CredentialPicker({ kind, value, onChange }: Props) {
         </button>
       </div>
 
-      {managing && <CredentialsDialog onClose={closeManager} />}
+      {/* No cleanup needed on close: the manager broadcasts after every
+          successful mutation, so this picker (and any sibling) already
+          re-synced and clamped via the credentials-changed listener. */}
+      {managing && <CredentialsDialog onClose={() => setManaging(false)} />}
 
       {adding && (
         <div className="border border-border rounded-sm p-3 bg-surface2 space-y-2">

--- a/ui/components/credentials-dialog.tsx
+++ b/ui/components/credentials-dialog.tsx
@@ -1,7 +1,9 @@
 'use client';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Eye, EyeOff, KeyRound, KeySquare, Lock, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react';
 import { api, errMessage } from '@/lib/tauri';
+import { emitCredentialsChanged } from '@/lib/credential-events';
 import { toast } from '@/lib/toast';
 import type { CredentialDetail, CredentialKind } from '@/lib/types';
 import { ConfirmDialog } from './confirm-dialog';
@@ -33,6 +35,9 @@ export function CredentialsDialog({ onClose }: Props) {
   const [addSecret, setAddSecret] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<CredentialDetail | null>(null);
   const [busy, setBusy] = useState(false);
+  // Re-entrancy guard for run(): state alone is stale within one tick, so
+  // a double-Enter in the rename input could launch concurrent mutations.
+  const busyRef = useRef(false);
 
   const reload = useCallback(async () => {
     try {
@@ -59,39 +64,50 @@ export function CredentialsDialog({ onClose }: Props) {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return;
       // Capture phase + stopPropagation: this dialog can be nested inside
       // the session dialog (via CredentialPicker), whose own bubble-phase
-      // Escape handler would otherwise close both layers at once. Escape
-      // unwinds one layer at a time: confirm → inline edit → dialog.
-      e.preventDefault();
-      e.stopPropagation();
-      if (busy) return;
-      if (confirmDelete) {
-        setConfirmDelete(null);
-      } else if (edit || addKind) {
-        setEdit(null);
-        setAddKind(null);
-      } else {
-        onClose();
+      // window handlers bind Escape (close) AND Ctrl/Cmd+Enter (save) —
+      // either would tear down the session editor underneath the open
+      // manager. Swallow both here; Escape unwinds one layer at a time:
+      // confirm → inline edit → dialog. Never gated on busy — a hung
+      // mutation must not leave Escape dead for the whole app.
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (confirmDelete) {
+          setConfirmDelete(null);
+        } else if (edit || addKind) {
+          setEdit(null);
+          setAddKind(null);
+        } else {
+          onClose();
+        }
+      } else if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
       }
     }
     window.addEventListener('keydown', onKey, true);
     return () => window.removeEventListener('keydown', onKey, true);
-  }, [busy, edit, addKind, confirmDelete, onClose]);
+  }, [edit, addKind, confirmDelete, onClose]);
 
   /** Run a mutation + reload. Returns false on failure so callers keep
-   *  the inline form (and whatever the user typed) open. */
+   *  the inline form (and whatever the user typed) open. Re-entrant
+   *  calls are dropped while a mutation is in flight. */
   async function run(fn: () => Promise<void>): Promise<boolean> {
+    if (busyRef.current) return false;
+    busyRef.current = true;
     setBusy(true);
     try {
       await fn();
       await reload();
+      emitCredentialsChanged();
       return true;
     } catch (e) {
       toast.danger('Action failed', errMessage(e));
       return false;
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
   }
@@ -111,7 +127,10 @@ export function CredentialsDialog({ onClose }: Props) {
     if (edit?.mode !== 'replace' || !edit.secret) return;
     const secret = edit.secret;
     const ok = await run(async () => {
-      await api.credentialUpdate(current.id, current.label, secret);
+      // label: null — rotating never writes the label, so a stale list
+      // can't silently revert a rename done elsewhere (or on a synced
+      // device) in the meantime.
+      await api.credentialUpdate(current.id, null, secret);
       toast.success('Secret updated', current.label);
     });
     if (ok) setEdit(null);
@@ -132,29 +151,27 @@ export function CredentialsDialog({ onClose }: Props) {
   }
 
   async function doDelete(c: CredentialDetail) {
-    await run(async () => {
+    const ok = await run(async () => {
       await api.credentialDelete(c.id);
       toast.success('Credential deleted', c.label);
     });
-    setConfirmDelete(null);
+    // Keep the confirm open on failure — closing it would make a failed
+    // delete look successful apart from a transient toast.
+    if (ok) setConfirmDelete(null);
   }
 
-  return (
+  // Portaled to <body>: the dialog can be opened from CredentialPicker
+  // inside the session editor's <form> (Enter would implicitly submit it)
+  // and inside AuthFixOverlay, whose backdrop-filter creates a containing
+  // block that re-anchors `fixed` descendants to the terminal pane.
+  // Escaping the DOM tree sidesteps both.
+  return createPortal(
     <div
       className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 overlay-in"
       role="dialog"
       aria-modal="true"
       aria-label="Credentials"
-      onMouseDown={(e) => { if (e.target === e.currentTarget && !busy) onClose(); }}
-      onKeyDown={(e) => {
-        // When opened from CredentialPicker this dialog sits inside the
-        // session editor's <form>; Enter in a text input would implicitly
-        // submit (and close) that editor. Inputs handle Enter themselves
-        // (rename row), so block only the default form submission.
-        if (e.key === 'Enter' && (e.target as HTMLElement).tagName === 'INPUT') {
-          e.preventDefault();
-        }
-      }}
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="w-[600px] max-w-full max-h-[85vh] bg-surface border border-border rounded-md shadow-dialog overflow-hidden dialog-in flex flex-col">
         <div className="px-4 py-3 border-b border-border bg-surface2/30 flex items-center justify-between">
@@ -275,6 +292,7 @@ export function CredentialsDialog({ onClose }: Props) {
                             placeholder={`New ${g.secretLabel.toLowerCase()}`}
                             value={edit.secret}
                             onChange={(secret) => setEdit({ ...edit, secret })}
+                            onEnter={() => saveReplace(c)}
                             ariaLabel={`New secret for ${c.label}`}
                           />
                           <div className="flex gap-2 justify-end">
@@ -306,6 +324,7 @@ export function CredentialsDialog({ onClose }: Props) {
                         placeholder="Label (e.g. 'Prod server key')"
                         value={addLabel}
                         onChange={(e) => setAddLabel(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') saveAdd(); }}
                         aria-label={`New ${g.title} label`}
                         autoFocus
                       />
@@ -314,6 +333,7 @@ export function CredentialsDialog({ onClose }: Props) {
                         placeholder={g.secretLabel}
                         value={addSecret}
                         onChange={setAddSecret}
+                        onEnter={saveAdd}
                         ariaLabel={`New ${g.title} secret`}
                       />
                       <div className="flex gap-2 justify-end">
@@ -345,8 +365,7 @@ export function CredentialsDialog({ onClose }: Props) {
           <button
             type="button"
             onClick={onClose}
-            disabled={busy}
-            className="px-3 py-1.5 border border-border rounded text-sm hover:bg-surface2 focus-ring disabled:opacity-50"
+            className="px-3 py-1.5 border border-border rounded text-sm hover:bg-surface2 focus-ring"
           >
             Close
           </button>
@@ -369,17 +388,21 @@ export function CredentialsDialog({ onClose }: Props) {
           onConfirm={() => doDelete(confirmDelete)}
         />
       )}
-    </div>
+    </div>,
+    document.body,
   );
 }
 
 function SecretInput({
-  kind, placeholder, value, onChange, ariaLabel,
+  kind, placeholder, value, onChange, onEnter, ariaLabel,
 }: {
   kind: CredentialKind;
   placeholder: string;
   value: string;
   onChange: (v: string) => void;
+  /** Enter-to-save for the single-line variant; the private-key textarea
+   *  keeps Enter for newlines. */
+  onEnter?: () => void;
   ariaLabel: string;
 }) {
   const [show, setShow] = useState(false);
@@ -404,6 +427,7 @@ function SecretInput({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') onEnter?.(); }}
         aria-label={ariaLabel}
       />
       <button

--- a/ui/components/sessions-sidebar.tsx
+++ b/ui/components/sessions-sidebar.tsx
@@ -995,7 +995,15 @@ export function SessionsSidebar() {
       )}
 
       {credentialsOpen && (
-        <CredentialsDialog onClose={() => setCredentialsOpen(false)} />
+        <CredentialsDialog
+          onClose={() => {
+            setCredentialsOpen(false);
+            // Deleting a credential nulls sessions' references in the DB
+            // (ON DELETE SET NULL); refresh so an Edit doesn't seed the
+            // dialog from a stale row and re-write the dangling id.
+            reload();
+          }}
+        />
       )}
 
       {backupOpen && (

--- a/ui/lib/credential-events.ts
+++ b/ui/lib/credential-events.ts
@@ -1,0 +1,17 @@
+/** In-app broadcast for vault credential mutations. The credential
+ *  manager can rename/delete credentials of any kind while multiple
+ *  CredentialPickers are mounted (the session editor shows a private-key
+ *  picker and a passphrase picker side by side), so every picker
+ *  subscribes and re-syncs its list — including the ones that didn't
+ *  open the manager. */
+const EVENT = 'ezterm:credentials-changed';
+
+export function emitCredentialsChanged() {
+  window.dispatchEvent(new Event(EVENT));
+}
+
+/** Returns the unsubscribe function. */
+export function onCredentialsChanged(fn: () => void): () => void {
+  window.addEventListener(EVENT, fn);
+  return () => window.removeEventListener(EVENT, fn);
+}

--- a/ui/lib/tauri.ts
+++ b/ui/lib/tauri.ts
@@ -92,9 +92,10 @@ export const api = {
   credentialListDetailed: () => invoke<CredentialDetail[]>('credential_list_detailed'),
   credentialCreate: (kind: CredentialKind, label: string, plaintext: string) =>
     invoke<CredentialMeta>('credential_create', { kind, label, plaintext }),
-  /** Rename and/or replace the secret. `plaintext: null` keeps the
-   *  existing ciphertext (rename-only). */
-  credentialUpdate: (id: number, label: string, plaintext: string | null) =>
+  /** Rename and/or replace the secret — fields are independent. `null`
+   *  keeps the existing value, so a rotate never echoes back a (possibly
+   *  stale) label and a rename never re-sends the secret. */
+  credentialUpdate: (id: number, label: string | null, plaintext: string | null) =>
     invoke<void>('credential_update', { id, label, plaintext }),
   credentialDelete: (id: number) => invoke<void>('credential_delete', { id }),
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
Follow-up to #112 (credential manager, #111) — applies all 10 findings from the post-merge review.

## Correctness

- **Dangling credential ids can't be saved anymore.** New `ui/lib/credential-events.ts` broadcast fires after every successful manager mutation; every mounted `CredentialPicker` re-syncs its list and clamps a selection that no longer exists. This covers the sibling-picker case (private key + passphrase pickers mounted together) and session forms seeded from stale rows. The sidebar also reloads sessions when the manager closes. Previously these paths re-wrote deleted ids and failed with `FOREIGN KEY constraint failed`.
- **Ctrl/Cmd+Enter no longer leaks** through to the session editor's window-level save handler while the manager is open (capture-phase swallow, alongside the existing Escape handling).
- **True modal everywhere**: the dialog is portaled to `<body>`. Opened from AuthFixOverlay, its `fixed` positioning was re-anchored by the overlay's `backdrop-filter` containing block (clipped + non-modal); the portal also takes it out of the session editor's `<form>`, replacing the Enter-`preventDefault` workaround.
- **Label and secret updates are independent**: `credential_update` takes `label: Option<String>`, and the two DB update functions merged into one COALESCE-based `UPDATE`. Rotating a secret no longer echoes back a render-time label, so a stale list (failed reload, cloud-sync rename from another device) can't silently revert a rename.
- **Plaintext zeroized on all paths**: `credential_create` / `credential_update` wrap the incoming secret in `Zeroizing` immediately, so validation errors and a failed `encrypt_with` (vault auto-locked mid-operation) no longer skip the cleanup.

## Robustness / UX

- `run()` re-entrancy guard (`busyRef`) — double-Enter can't launch concurrent mutations.
- A failed delete keeps the confirm dialog open instead of looking successful.
- Escape is never gated on `busy` (a hung mutation previously left Escape dead app-wide) and unwinds one layer at a time.
- Enter saves in the add and replace-secret forms, matching the rename row; the private-key textarea keeps Enter for newlines.

## Verification

- `cargo check` — clean; `cargo test` — 92 passed (update test now covers rename-only, rotate-only, both, and NotFound)
- `npm run lint` — no new warnings; `tsc --noEmit` — clean
- Version bumped 1.8.0 → 1.8.1