### PR TITLE
fix(forwards): show & persist forwards created from the per-tab pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.8.1"
+version = "1.9.0"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/src-tauri/src/commands/forwards.rs
+++ b/src-tauri/src/commands/forwards.rs
@@ -194,6 +194,34 @@ pub async fn forward_stop_all(
 
 // ---------- Internal helpers ----------
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_ephemeral_dynamic_target() {
+        // Exact JSON the forward-dialog sends for an ephemeral dynamic
+        // (SOCKS) forward. The outer enum is internally tagged on "kind"
+        // while the nested ForwardSpec ALSO has a "kind" field.
+        let json = r#"{"kind":"ephemeral","spec":{"name":"socks","kind":"dynamic","bind_addr":"127.0.0.1","bind_port":1080,"dest_addr":"","dest_port":0}}"#;
+        let target: ForwardStartTarget = serde_json::from_str(json).expect("ephemeral dynamic target must deserialize");
+        match target {
+            ForwardStartTarget::Ephemeral { spec } => {
+                assert_eq!(spec.kind, ForwardKind::Dynamic);
+                assert_eq!(spec.bind_port, 1080);
+            }
+            _ => panic!("expected Ephemeral variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_persistent_target() {
+        let json = r#"{"kind":"persistent","id":7}"#;
+        let target: ForwardStartTarget = serde_json::from_str(json).expect("persistent target must deserialize");
+        assert!(matches!(target, ForwardStartTarget::Persistent { id: 7 }));
+    }
+}
+
 pub(crate) fn spec_from_db(f: &db::forwards::Forward) -> Result<ForwardSpec> {
     let kind = match f.kind.as_str() {
         "local"   => ForwardKind::Local,

--- a/src-tauri/src/db/forwards.rs
+++ b/src-tauri/src/db/forwards.rs
@@ -214,4 +214,65 @@ mod tests {
         let mut i = base(); i.kind = "udp".into();
         assert!(validate_input(&i).is_err());
     }
+
+    async fn pool() -> SqlitePool {
+        let p = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        crate::db::init_pool_from_pool(&p).await.unwrap();
+        // Seed a session row so the FK on session_forwards is satisfiable.
+        sqlx::query(
+            "INSERT INTO sessions (id, name, host, username, auth_type) \
+             VALUES (1, 'test', 'example.com', 'root', 'password')",
+        )
+        .execute(&p)
+        .await
+        .unwrap();
+        p
+    }
+
+    fn dynamic_input() -> ForwardInput {
+        ForwardInput {
+            name: "socks".into(),
+            kind: "dynamic".into(),
+            bind_addr: "127.0.0.1".into(),
+            bind_port: 1080,
+            dest_addr: String::new(),
+            dest_port: 0,
+            auto_start: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn dynamic_create_persists_and_lists() {
+        let p = pool().await;
+        let created = create(&p, 1, &dynamic_input()).await.unwrap();
+        assert_eq!(created.kind, "dynamic");
+        let rows = list_for_session(&p, 1).await.unwrap();
+        assert_eq!(rows.len(), 1, "dynamic forward should persist + list back");
+        assert_eq!(rows[0].kind, "dynamic");
+    }
+
+    #[test]
+    fn input_deserializes_from_frontend_dynamic_json() {
+        // Exact JSON the forward-dialog builds for a persistent dynamic
+        // forward (dest_addr:'' dest_port:0).
+        let json = r#"{"name":"socks","kind":"dynamic","bind_addr":"127.0.0.1","bind_port":1080,"dest_addr":"","dest_port":0,"auto_start":1}"#;
+        let parsed: ForwardInput = serde_json::from_str(json).expect("dynamic ForwardInput must deserialize");
+        assert_eq!(parsed.kind, "dynamic");
+        validate_input(&parsed).expect("dynamic input must validate");
+    }
+
+    #[tokio::test]
+    async fn all_kinds_persist() {
+        let p = pool().await;
+        let mut local = base(); local.bind_port = 5432;
+        let mut remote = base(); remote.kind = "remote".into(); remote.bind_port = 8080;
+        create(&p, 1, &local).await.unwrap();
+        create(&p, 1, &remote).await.unwrap();
+        create(&p, 1, &dynamic_input()).await.unwrap();
+        assert_eq!(list_for_session(&p, 1).await.unwrap().len(), 3);
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/components/forward-dialog.tsx
+++ b/ui/components/forward-dialog.tsx
@@ -11,12 +11,18 @@ import type {
 type Mode =
   | { mode: 'persistent-create'; sessionId: number }
   | { mode: 'persistent-edit';   forward: Forward }
-  | { mode: 'ephemeral-create';  connectionId: number }
+  | { mode: 'ephemeral-create';  connectionId: number; sessionId?: number }
   | { mode: 'ephemeral-edit';    connectionId: number; existing: RuntimeForward };
+
+/** A save can yield a persistent row (DB-backed), a runtime forward
+ *  (started on a tab), or both — when the per-tab pane saves to the
+ *  session *and* starts it on the active connection. Callers update
+ *  whichever lists are relevant to them. */
+export type ForwardSaveResult = { persistent?: Forward; runtime?: RuntimeForward };
 
 type Props = Mode & {
   onClose: () => void;
-  onSaved: (result: Forward | RuntimeForward) => void;
+  onSaved: (result: ForwardSaveResult) => void;
 };
 
 const KIND_TILES: { value: ForwardKind; label: string; hint: string; Icon: LucideIcon }[] = [
@@ -55,6 +61,15 @@ export function ForwardDialog(props: Props) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  // The per-tab pane can offer to persist the forward to the session
+  // (so it survives reconnects) instead of being tab-only. Only when we
+  // know a real, saved session id to attach it to.
+  const persistSessionId =
+    props.mode === 'ephemeral-create' && props.sessionId != null && props.sessionId > 0
+      ? props.sessionId
+      : null;
+  const [persist, setPersist] = useState(false);
+
   const isPersistent = props.mode === 'persistent-create' || props.mode === 'persistent-edit';
   const isDynamic    = v.kind === 'dynamic';
   const nonLoopback  = v.bind_addr.trim() !== '' &&
@@ -70,32 +85,45 @@ export function ForwardDialog(props: Props) {
       if (v.dest_port < 1 || v.dest_port > 65535) return setErr('Destination port must be 1–65535');
     }
     setBusy(true);
+    const dest_addr = isDynamic ? '' : v.dest_addr;
+    const dest_port = isDynamic ? 0  : v.dest_port;
     try {
       if (isPersistent) {
         const input: ForwardInput = {
           name: v.name, kind: v.kind,
           bind_addr: v.bind_addr, bind_port: v.bind_port,
-          dest_addr: isDynamic ? '' : v.dest_addr,
-          dest_port: isDynamic ?  0 : v.dest_port,
+          dest_addr, dest_port,
           auto_start: v.auto_start,
         };
         const out = props.mode === 'persistent-create'
           ? await api.forwardCreate(props.sessionId, input)
           : await api.forwardUpdate(props.forward.id, input);
-        props.onSaved(out);
+        props.onSaved({ persistent: out });
+        props.onClose();
+      } else if (props.mode === 'ephemeral-create' && persist && persistSessionId != null) {
+        // Save to the session (persistent) AND start it on this tab so
+        // it's live now and comes back on the next connect.
+        const input: ForwardInput = {
+          name: v.name, kind: v.kind,
+          bind_addr: v.bind_addr, bind_port: v.bind_port,
+          dest_addr, dest_port,
+          auto_start: v.auto_start,
+        };
+        const created = await api.forwardCreate(persistSessionId, input);
+        const rf = await api.forwardStart(props.connectionId, { kind: 'persistent', id: created.id });
+        props.onSaved({ persistent: created, runtime: rf });
         props.onClose();
       } else {
         const spec: ForwardSpec = {
           name: v.name, kind: v.kind,
           bind_addr: v.bind_addr, bind_port: v.bind_port,
-          dest_addr: isDynamic ? '' : v.dest_addr,
-          dest_port: isDynamic ?  0 : v.dest_port,
+          dest_addr, dest_port,
         };
         if (props.mode === 'ephemeral-edit') {
           await api.forwardStop(props.connectionId, props.existing.runtime_id).catch(() => {});
         }
         const rf = await api.forwardStart(props.connectionId, { kind: 'ephemeral', spec });
-        props.onSaved(rf);
+        props.onSaved({ runtime: rf });
         props.onClose();
       }
     } catch (e) {
@@ -179,7 +207,15 @@ export function ForwardDialog(props: Props) {
             </div>
           )}
 
-          {isPersistent && (
+          {persistSessionId != null && (
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={persist}
+                     onChange={(e) => setPersist(e.target.checked)} />
+              <span className="text-sm">Save to this session (persists across reconnects)</span>
+            </label>
+          )}
+
+          {(isPersistent || persist) && (
             <label className="flex items-center gap-2">
               <input type="checkbox" checked={v.auto_start === 1}
                      onChange={(e) => setV({ ...v, auto_start: e.target.checked ? 1 : 0 })} />

--- a/ui/components/forwards-pane.tsx
+++ b/ui/components/forwards-pane.tsx
@@ -92,9 +92,26 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
     return () => { cancelled = true; unsub?.(); };
   }, [connectionId]);
 
+  // The runtime layer deliberately does NOT emit an initial "Running"
+  // status event (see ssh/forwards/local.rs) — the awaited return value
+  // of forward_start/forward_create carries that summary, and the caller
+  // is responsible for folding it into the list. Upsert by runtime_id so
+  // a started/created forward shows up (and flips to running) immediately
+  // instead of only appearing after the next status event or reconnect.
+  const upsertRuntime = (rf: RuntimeForward) => setRuntime((cur) => {
+    const idx = cur.findIndex((x) => x.runtime_id === rf.runtime_id);
+    if (idx === -1) return [...cur, rf];
+    const next = cur.slice();
+    next[idx] = rf;
+    return next;
+  });
+
   async function startPersistent(id: number) {
     if (connectionId == null) return;
-    try { await api.forwardStart(connectionId, { kind: 'persistent', id }); }
+    try {
+      const rf = await api.forwardStart(connectionId, { kind: 'persistent', id });
+      upsertRuntime(rf);
+    }
     catch (e) { toast.danger('Start failed', String((e as { message?: string })?.message ?? e)); }
   }
   async function stop(runtimeId: number) {
@@ -194,15 +211,28 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
       </div>
 
       {dialog?.kind === 'ephemeral-create' && connectionId != null && (
-        <ForwardDialog mode="ephemeral-create" connectionId={connectionId}
+        <ForwardDialog mode="ephemeral-create" connectionId={connectionId} sessionId={sessionId}
                        onClose={() => setDialog(null)}
-                       onSaved={() => setDialog(null)} />
+                       onSaved={(r) => {
+                         const { persistent, runtime } = r;
+                         if (persistent) setPersistent((cur) => [...cur, persistent]);
+                         if (runtime) upsertRuntime(runtime);
+                         setDialog(null);
+                       }} />
       )}
       {dialog?.kind === 'ephemeral-edit' && connectionId != null && (
         <ForwardDialog mode="ephemeral-edit" connectionId={connectionId}
                        existing={dialog.existing}
                        onClose={() => setDialog(null)}
-                       onSaved={() => setDialog(null)} />
+                       onSaved={(r) => {
+                         const oldId = dialog.existing.runtime_id;
+                         const { runtime } = r;
+                         setRuntime((cur) => {
+                           const without = cur.filter((x) => x.runtime_id !== oldId);
+                           return runtime ? [...without, runtime] : without;
+                         });
+                         setDialog(null);
+                       }} />
       )}
     </div>
   );

--- a/ui/components/session-dialog.tsx
+++ b/ui/components/session-dialog.tsx
@@ -1005,17 +1005,18 @@ function ForwardsConfigPane({ sessionId }: { sessionId: number | null }) {
       {editing === 'new' && (
         <ForwardDialog mode="persistent-create" sessionId={sessionId}
                        onClose={() => setEditing(null)}
-                       onSaved={(out) => {
-                         setRows((cur) => [...cur, out as Forward]);
+                       onSaved={(r) => {
+                         const { persistent } = r;
+                         if (persistent) setRows((cur) => [...cur, persistent]);
                          setEditing(null);
                        }} />
       )}
       {editing && editing !== 'new' && (
         <ForwardDialog mode="persistent-edit" forward={editing as Forward}
                        onClose={() => setEditing(null)}
-                       onSaved={(out) => {
-                         const upd = out as Forward;
-                         setRows((cur) => cur.map((x) => x.id === upd.id ? upd : x));
+                       onSaved={(r) => {
+                         const { persistent } = r;
+                         if (persistent) setRows((cur) => cur.map((x) => x.id === persistent.id ? persistent : x));
                          setEditing(null);
                        }} />
       )}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
## Problem
Saving a **Dynamic Forward (SOCKS proxy)** from the per-tab Forwards side-pane appeared to do nothing — the forward never showed up, and nothing persisted across reconnects. It affected all forward kinds, but Dynamic was the most visible since the pane is its only entry point.

## Root cause
The runtime layer intentionally does **not** emit an initial `Running` status event — by contract, the awaited return value of `forward_start`/`forward_create` carries that summary and the caller must fold it into the list (`ssh/forwards/local.rs`). The session-config screen did this; the **per-tab pane discarded the return value**:

- `forwards-pane` `onSaved` handlers + `startPersistent` ignored the returned forward → newly created/started forwards never rendered.
- Pane forwards were ephemeral-only → never survived a reconnect.

The Rust persistence + IPC paths were already correct (verified with new tests for all kinds, including the exact JSON the UI sends).

## Changes
- **forward-dialog**: `ephemeral-create` accepts the session id and offers a **"Save to this session"** checkbox (persist to the session *and* start it on the tab) plus the auto-start toggle. `onSaved` now returns `{ persistent?, runtime? }`.
- **forwards-pane**: `upsertRuntime` folds the returned summary into state from `startPersistent` and both `onSaved` handlers, so forwards appear/flip-to-running immediately.
- **session-dialog**: updated the two `onSaved` callers to the new result shape.
- **tests**: dynamic/all-kind persistence + IPC deserialization of `ForwardInput` and the internally-tagged `ForwardStartTarget`.

Version bumped 1.8.1 → 1.9.0 (Cargo workspace, tauri.conf.json, ui/package.json).

## Verification
`cargo check` ✓ · `cargo test forwards` 22 passed ✓ · `tsc --noEmit` ✓ · `eslint` ✓ (one pre-existing unrelated warning). Not yet driven in a live GUI.