### PR TITLE
Site SEO: IndexNow on deploy + SERP-length titles and meta descriptions

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -60,3 +60,25 @@ jobs:
       - name: Deploy to Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # Tell IndexNow-family engines (Bing, Yandex, Seznam, Naver) the site
+      # changed so they recrawl within minutes instead of days. Google does
+      # not use IndexNow — it discovers via the sitemap in Search Console.
+      # The key is NOT a secret: engines verify ownership by fetching
+      # public/<key>.txt from the live site, so it must match that filename.
+      # continue-on-error: an IndexNow outage must never fail a deploy.
+      - name: Submit sitemap URLs to IndexNow
+        continue-on-error: true
+        env:
+          INDEXNOW_KEY: fc2e8a4b7218fe19b3d54bba2d8215cb
+          INDEXNOW_HOST: ezterm.zerosandones.us
+        run: |
+          PAYLOAD=$(grep -oP '(?<=<loc>)[^<]+' site/dist/sitemap.xml \
+            | jq -R . \
+            | jq -s --arg host "$INDEXNOW_HOST" --arg key "$INDEXNOW_KEY" \
+                '{host: $host, key: $key, keyLocation: ("https://" + $host + "/" + $key + ".txt"), urlList: .}')
+          echo "$PAYLOAD"
+          curl -sS --fail-with-body -X POST "https://api.indexnow.org/indexnow" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD" \
+            -w "\nIndexNow HTTP %{http_code}\n"

--- a/site/README.md
+++ b/site/README.md
@@ -17,7 +17,10 @@ npm test                 # vitest (version parser)
 - New docs page → `src/content/docs/<section>/<slug>.md`. The sidebar `autogenerate` picks it up automatically for `features/`; other sections need a manual entry in `astro.config.mjs` → `starlight.sidebar`.
 - New screenshot → drop a PNG/WebP in `public/screenshots/` and reference it through `${BASE}screenshots/<name>.png` so the path stays correct if the deploy base ever changes.
 - Release notes → edit `../docs/release-notes/v<n>.md`. The `/changelog/` page picks new files up automatically on the next build, sorted by semver descending.
+- SEO: give every page a ~50–60 char `<title>` and a ~140–160 char `description`. On docs pages keep the frontmatter `title` short (it's the H1 and sidebar label) and override the tab/SERP title via `head:` → `- tag: title` — see any existing docs page.
 
 ## Deploy
 
 Pushes to `main` that touch `site/**` or `docs/release-notes/**` trigger `.github/workflows/site.yml`, which builds and deploys to GitHub Pages.
+
+After each deploy the workflow submits every sitemap URL to [IndexNow](https://www.indexnow.org/) so Bing/Yandex-family engines recrawl within minutes (Google ignores IndexNow — it discovers changes via the sitemap registered in Search Console). The key file `public/fc2e8a4b7218fe19b3d54bba2d8215cb.txt` is public by design: engines fetch it from the live site to verify domain ownership. Don't delete or rename it — it must match `INDEXNOW_KEY` in `site.yml`.

--- a/site/public/fc2e8a4b7218fe19b3d54bba2d8215cb.txt
+++ b/site/public/fc2e8a4b7218fe19b3d54bba2d8215cb.txt
@@ -1,0 +1,1 @@
+fc2e8a4b7218fe19b3d54bba2d8215cb

--- a/site/scripts/post-build.mjs
+++ b/site/scripts/post-build.mjs
@@ -6,6 +6,9 @@
 //    Astro's compact one-line output with news/xhtml/image/video namespaces
 //    can trip strict parsers (e.g. GSC sometimes reports "could not be read"
 //    on the dense form).
+// 4. Drop /download/ from the sitemap — that page is noindex (JS redirect to
+//    GitHub Releases), and a noindex URL in a sitemap reads as a
+//    contradiction in Search Console / Bing Webmaster reports.
 import fs from 'node:fs';
 
 const DIST = 'dist';
@@ -21,7 +24,9 @@ if (fs.existsSync(`${DIST}/sitemap-index.xml`)) {
 
 if (fs.existsSync(`${DIST}/sitemap.xml`)) {
   const raw = fs.readFileSync(`${DIST}/sitemap.xml`, 'utf8');
-  const locs = [...raw.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+  const locs = [...raw.matchAll(/<loc>([^<]+)<\/loc>/g)]
+    .map((m) => m[1])
+    .filter((u) => !/\/download\/?$/.test(u));
   if (locs.length > 0) {
     const body = locs
       .map((u) => `  <url>\n    <loc>${u}</loc>\n  </url>`)

--- a/site/src/content/docs/docs/faq.md
+++ b/site/src/content/docs/docs/faq.md
@@ -1,6 +1,9 @@
 ---
 title: FAQ
-description: Frequently asked questions.
+description: "Answers to common ezTerm questions — GPLv3 licensing, Windows, Linux, and macOS support, Tauri vs Electron, session import, data storage, and security."
+head:
+  - tag: title
+    content: "ezTerm FAQ — Licensing, Platforms, Features & Security"
 ---
 
 ## Is it really free?

--- a/site/src/content/docs/docs/features/local-shells.md
+++ b/site/src/content/docs/docs/features/local-shells.md
@@ -1,6 +1,9 @@
 ---
 title: Local shells
-description: cmd, PowerShell, or any local shell as a tab.
+description: "Run cmd, PowerShell, pwsh, or any local executable as an ezTerm tab — keep local shells, WSL distros, and remote SSH sessions together in one window."
+head:
+  - tag: title
+    content: "Local Shell Tabs in ezTerm — cmd, PowerShell & Custom"
 sidebar:
   order: 4
 ---

--- a/site/src/content/docs/docs/features/port-forwarding.md
+++ b/site/src/content/docs/docs/features/port-forwarding.md
@@ -1,6 +1,9 @@
 ---
 title: Port forwarding
-description: Local, remote, and dynamic (SOCKS5) forwards.
+description: "Set up local, remote, and dynamic (SOCKS5) SSH port forwards in ezTerm — persistent or ad-hoc tunnels with OpenSSH semantics and safe loopback defaults."
+head:
+  - tag: title
+    content: "SSH Port Forwarding in ezTerm — Local, Remote & SOCKS5"
 sidebar:
   order: 6
 ---

--- a/site/src/content/docs/docs/features/sftp.md
+++ b/site/src/content/docs/docs/features/sftp.md
@@ -1,6 +1,9 @@
 ---
 title: SFTP
-description: File transfer side-pane on the same SSH connection.
+description: "ezTerm docks an SFTP file browser beside your terminal on the same SSH connection — browse, upload, download, and manage remote files with no second login."
+head:
+  - tag: title
+    content: "SFTP File Browser in ezTerm — Transfers on One Connection"
 sidebar:
   order: 2
 ---

--- a/site/src/content/docs/docs/features/ssh.md
+++ b/site/src/content/docs/docs/features/ssh.md
@@ -1,6 +1,9 @@
 ---
 title: SSH
-description: russh-backed sessions with password, key, or agent auth.
+description: "How SSH works in ezTerm — password, private-key, and agent authentication, host-key TOFU verification, keepalives, timeouts, and compression via russh."
+head:
+  - tag: title
+    content: "SSH in ezTerm — Password, Key & Agent Auth, Host-Key TOFU"
 sidebar:
   order: 1
 ---

--- a/site/src/content/docs/docs/features/vault.md
+++ b/site/src/content/docs/docs/features/vault.md
@@ -1,6 +1,9 @@
 ---
 title: Vault
-description: Encrypted credential storage. Argon2id + ChaCha20-Poly1305.
+description: "Every secret ezTerm stores is encrypted in a local vault — Argon2id key derivation, ChaCha20-Poly1305 encryption, zeroized plaintext, encrypted backups."
+head:
+  - tag: title
+    content: "ezTerm Vault — Encrypted SSH Credential & Key Storage"
 sidebar:
   order: 7
 ---

--- a/site/src/content/docs/docs/features/wsl.md
+++ b/site/src/content/docs/docs/features/wsl.md
@@ -1,6 +1,9 @@
 ---
 title: WSL
-description: WSL distros as tabs under ConPTY.
+description: "Open WSL distros as ezTerm terminal tabs under ConPTY — full ANSI color, Windows-Linux interop, and your local Linux shells alongside SSH sessions."
+head:
+  - tag: title
+    content: "WSL Tabs in ezTerm — Linux Distro Terminals on Windows"
 sidebar:
   order: 3
 ---

--- a/site/src/content/docs/docs/features/x11-forwarding.md
+++ b/site/src/content/docs/docs/features/x11-forwarding.md
@@ -1,6 +1,9 @@
 ---
 title: X11 forwarding
-description: Run remote Linux GUI apps as native Windows windows.
+description: "ezTerm bundles VcXsrv so X11 forwarding works out of the box on Windows — remote Linux GUI apps open as native windows; Linux and macOS use your X server."
+head:
+  - tag: title
+    content: "X11 Forwarding in ezTerm — Remote Linux GUI Apps on Windows"
 sidebar:
   order: 5
 ---

--- a/site/src/content/docs/docs/getting-started/first-connect.md
+++ b/site/src/content/docs/docs/getting-started/first-connect.md
@@ -1,6 +1,9 @@
 ---
 title: First connect
-description: Create a session, connect, and run a command.
+description: "Create your first ezTerm SSH session — set a master password, save a session with password or key auth, connect in a tab, and try the SFTP side-pane."
+head:
+  - tag: title
+    content: "Your First SSH Connection in ezTerm — Quick-Start Guide"
 ---
 
 After setting your master password, you'll see the empty sessions sidebar. Let's connect to a server.

--- a/site/src/content/docs/docs/getting-started/importing-from-mobaxterm.md
+++ b/site/src/content/docs/docs/getting-started/importing-from-mobaxterm.md
@@ -1,6 +1,9 @@
 ---
 title: Import from MobaXterm
-description: Bring SSH and WSL sessions over from MobaXterm.
+description: "Migrate from MobaXterm to ezTerm — import .mxtsessions exports with folder structure intact while private keys move into the encrypted vault automatically."
+head:
+  - tag: title
+    content: "Import MobaXterm Sessions into ezTerm — Migration Guide"
 ---
 
 ezTerm can read MobaXterm's session exports and recreate them — including the folder structure and any private-key files referenced by the sessions.

--- a/site/src/content/docs/docs/getting-started/install.md
+++ b/site/src/content/docs/docs/getting-started/install.md
@@ -1,6 +1,9 @@
 ---
 title: Install
-description: How to install ezTerm on Windows, Linux, and macOS.
+description: "Install ezTerm on Windows, Linux, or macOS — download the self-contained binary, check runtime requirements, and get to your first SSH session in minutes."
+head:
+  - tag: title
+    content: "Install ezTerm on Windows, Linux & macOS — Setup Guide"
 ---
 
 ezTerm ships as a single self-contained binary — no installer required.

--- a/site/src/content/docs/docs/index.mdx
+++ b/site/src/content/docs/docs/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: ezTerm docs
-description: Documentation for ezTerm, a free, open-source SSH client.
+description: "Official ezTerm documentation — installation, your first SSH connection, MobaXterm import, and guides to SFTP, WSL, X11, port forwarding, and the vault."
+head:
+  - tag: title
+    content: "ezTerm Documentation — Free, Open-Source SSH Client Guides"
 template: doc
 ---
 

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -1,6 +1,9 @@
 ---
 title: Troubleshooting
-description: Common issues and fixes.
+description: "Fixes for common ezTerm problems — host-key mismatch errors, port-forward conflicts, missing X11 windows, vault unlock failures, and Linux library errors."
+head:
+  - tag: title
+    content: "ezTerm Troubleshooting — Fixes for Common SSH Client Issues"
 ---
 
 ## "Host key mismatch" hard-failure

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -55,8 +55,8 @@ const SITE = 'https://ezterm.zerosandones.us';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Changelog — ezTerm</title>
-    <meta name="description" content="Release history for ezTerm — the free, open-source SSH client. New features, fixes, and breaking changes per version." />
+    <title>ezTerm Changelog — Release Notes & Version History</title>
+    <meta name="description" content="ezTerm release history — new features, improvements, bug fixes, and breaking changes for every version of the free, open-source, cross-platform SSH client." />
     <link rel="canonical" href={`${SITE}/changelog/`} />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="ezTerm Changelog" />

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -17,7 +17,8 @@ const GA_ID = 'G-19V4705C82';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="robots" content="noindex" />
-    <title>Download ezTerm</title>
+    <title>Download ezTerm — Free SSH Client for Windows, Linux & macOS</title>
+    <meta name="description" content="Download the latest ezTerm release for Windows, Linux, or macOS — this page redirects to the newest build on GitHub Releases." />
     <link rel="canonical" href={`${SITE}/download/`} />
     <link rel="icon" type="image/png" href={`${BASE}ezterm-icon.png`} />
     <!--

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -10,7 +10,7 @@ import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 const BASE = import.meta.env.BASE_URL;
 const SITE = 'https://ezterm.zerosandones.us';
 const REPO = 'https://github.com/ZerosAndOnesLLC/ezTerm';
-const DESC = 'MobaXterm-style sessions, modern Rust core. SSH, SFTP, WSL, X11 forwarding, port forwarding, encrypted vault. Free, open-source, GPLv3.';
+const DESC = 'Free, open-source SSH client — MobaXterm-style sessions, SFTP side-pane, WSL tabs, X11 & port forwarding, encrypted vault. Rust-fast on Windows, Linux, macOS.';
 
 const jsonLd = {
   '@context': 'https://schema.org',

--- a/site/src/pages/screenshots.astro
+++ b/site/src/pages/screenshots.astro
@@ -51,8 +51,8 @@ const shots = [
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>Screenshots — ezTerm</title>
-    <meta name="description" content="Screenshots of ezTerm — sessions sidebar, tabbed terminals, SFTP side-pane, split panes, session config, and port forwarding." />
+    <title>ezTerm Screenshots — SSH Terminal, SFTP Pane & Split Views</title>
+    <meta name="description" content="See ezTerm in action — sessions sidebar, tabbed terminals, SFTP side-pane, split-pane grids, session configuration dialogs, and SSH port forwarding." />
     <link rel="canonical" href={`${SITE}/screenshots/`} />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="ezTerm Screenshots" />


### PR DESCRIPTION
Closes #120

## What changed

**IndexNow (new)**
- `site/public/fc2e8a4b7218fe19b3d54bba2d8215cb.txt` — key file served from the site root (public by design; engines fetch it to verify domain ownership).
- `site.yml` gains a post-deploy step that POSTs every sitemap URL to `api.indexnow.org` (fans out to Bing, Yandex, Seznam, Naver). `continue-on-error` so an IndexNow outage can never fail a deploy. Google ignores IndexNow — it still discovers via the GSC-registered sitemap.

**Titles (were 12–24 chars on docs pages)**
- Every docs page gets a ~50–60 char `<title>` via Starlight `head` frontmatter override — H1s and sidebar labels keep the short `title`. e.g. `SSH | ezTerm` → `SSH in ezTerm — Password, Key & Agent Auth, Host-Key TOFU`.
- `/changelog/`, `/screenshots/`, `/download/` titles lengthened to 50–60 chars.

**Meta descriptions (were 24–60 chars on docs pages)**
- All 13 docs pages + homepage/changelog/screenshots rewritten to ~140–160 chars, accurate to page content, cross-platform positioning (Windows, Linux, macOS).
- `/download/` was missing a description entirely — added.

**Sitemap hygiene**
- Post-build now drops the `noindex` `/download/` page from `sitemap.xml` (noindex-in-sitemap reads as a contradiction in GSC/Bing reports).

**Docs**
- `site/README.md`: SEO conventions for new pages + why the key file must not be deleted.

## Config-only change (no code)

`https_enforced` was **off** on the Pages config — `http://` URLs served 200 instead of redirecting. Enabled via API; `http://ezterm.zerosandones.us` now 301s to `https://`.

## Verification

- `npm test` — 9/9 pass; `npm run build` clean.
- Script-checked all 18 built pages: exactly one `<title>` each (Starlight head override dedupes correctly), all indexable pages 50–63 char titles, 147–158 char descriptions.
- `sitemap.xml`: 16 URLs, no `/download/`, no 404.
- Built `dist/` serves the IndexNow key file at the root.