### PR TITLE
fix(forwards): editable everywhere + reliable auto-start / edit / multi-tab behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ yarn-error.log*
 tmp-release-hashes/
 .release-notes-*.md
 .superpowers/
+target-test/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.10.0"
+version = "1.11.0"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ on those platforms.
   JetBrains tools, …) pop as native Windows windows. The Windows release
   tarball ships VcXsrv in a `vcxsrv/` subfolder so no separate install is
   needed.
+- **Port forwarding** — Local (`-L`), Remote (`-R`), and Dynamic / SOCKS5 (`-D`)
+  tunnels. Save them to a session to auto-start on connect, or add ad-hoc tunnels
+  to a live tab. A side pane shows each tunnel's live state (green running / red
+  stopped, amber when the port is already in use by another tab or window) with
+  start / stop / edit / delete from buttons or a right-click menu.
 - **MobaXterm import** — point at a `.mxtsessions` export or `MobaXterm.ini` and
   import SSH + WSL rows with their folder structure. Private-key files are read
   off disk and stored as encrypted vault credentials, auto-attached to the

--- a/src-tauri/src/commands/forwards.rs
+++ b/src-tauri/src/commands/forwards.rs
@@ -11,7 +11,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::commands::require_unlocked;
 use crate::db;
 use crate::error::{AppError, Result};
-use crate::ssh::forwards::{ForwardKind, ForwardSpec, RuntimeForwardSummary};
+use crate::ssh::forwards::{ForwardKind, ForwardSpec, ForwardStatus, RuntimeForwardSummary};
 use crate::state::AppState;
 
 // ---------- Persistent ----------
@@ -46,7 +46,7 @@ pub async fn forward_update(
     // Stop any currently-running runtime forwards backed by this
     // persistent id BEFORE writing the DB. Capture the connection ids
     // we stopped on so we can re-start with the new spec.
-    let stopped_on = stop_runtimes_for_persistent(&state, id).await;
+    let stopped_on = stop_runtimes_for_persistent(&state, id, true).await;
     let updated = db::forwards::update(&state.db, id, &input).await?;
     // Re-start using the freshly-updated row so the new spec is what
     // goes live. Failures emit error events as usual; we don't fail
@@ -63,19 +63,13 @@ pub async fn forward_update(
         let spec = new_spec.clone();
         let cid = conn.id;
         tokio::spawn(async move {
-            if let Err(e) = start_inner(cid, app2.clone(), forwards, handle, spec.clone(), Some(id)).await {
+            // start_inner emits its own status event (Running / Conflict /
+            // Error) carrying the real allocated runtime id, so we only log
+            // a hard failure here — no synthetic sentinel event.
+            if let Err(e) = start_inner(cid, app2, forwards, handle, spec.clone(), Some(id)).await {
                 tracing::warn!(
                     "post-update restart of forward {}:{} failed: {e}",
                     spec.bind_addr, spec.bind_port,
-                );
-                let _ = app2.emit(
-                    &format!("forwards:status:{cid}"),
-                    &serde_json::json!({
-                        "runtime_id":    0,
-                        "persistent_id": id,
-                        "spec":          spec,
-                        "status":        { "status": "error", "message": format!("restart after edit: {e}") },
-                    }),
                 );
             }
         });
@@ -89,7 +83,7 @@ pub async fn forward_delete(state: State<'_, AppState>, id: i64) -> Result<()> {
     // Stop any running runtime forwards for this persistent id before
     // dropping the DB row. Otherwise a running -R keeps tunneling to
     // a destination the user thought they deleted.
-    let _ = stop_runtimes_for_persistent(&state, id).await;
+    let _ = stop_runtimes_for_persistent(&state, id, false).await;
     db::forwards::delete(&state.db, id).await
 }
 
@@ -100,6 +94,7 @@ pub async fn forward_delete(state: State<'_, AppState>, id: i64) -> Result<()> {
 async fn stop_runtimes_for_persistent(
     state: &State<'_, AppState>,
     id: i64,
+    wait: bool,
 ) -> Vec<Arc<crate::ssh::registry::Connection>> {
     let mut stopped_on: Vec<Arc<crate::ssh::registry::Connection>> = Vec::new();
     for conn in state.ssh.list_all().await {
@@ -108,9 +103,10 @@ async fn stop_runtimes_for_persistent(
         for rt in runtimes {
             if rt.persistent_id == Some(id) {
                 if let Some(rf) = conn.forwards.remove(rt.runtime_id).await {
-                    if let Some(tx) = rf.stop_tx.lock().await.take() {
-                        let _ = tx.send(());
-                    }
+                    // `wait` when the caller is about to re-bind the same
+                    // address (edit-in-place restart) and needs the old
+                    // listener to release it first; otherwise fire-and-forget.
+                    if wait { rf.stop_and_wait().await; } else { rf.stop().await; }
                 }
                 touched = true;
             }
@@ -163,6 +159,30 @@ pub async fn forward_start(
                 conn.ssh_handle.clone(), spec, persistent_id).await
 }
 
+/// Replace a running ephemeral (tab-only) forward with a new spec —
+/// the edit-in-place path for the per-tab pane. Stops the old runtime
+/// and WAITS for its listener to release the bind before starting the
+/// new one, so re-using the same address doesn't race teardown and hit
+/// AddrInUse / "already forwarded". (Persistent forwards use
+/// `forward_update`, which has the same discipline.)
+#[tauri::command]
+pub async fn forward_replace(
+    state: State<'_, AppState>,
+    app: AppHandle,
+    connection_id: u64,
+    runtime_id: u64,
+    spec: ForwardSpec,
+) -> Result<RuntimeForwardSummary> {
+    require_unlocked(&state).await?;
+    let conn = state.ssh.get(connection_id).await
+        .ok_or(AppError::NotFound)?;
+    if let Some(rf) = conn.forwards.remove(runtime_id).await {
+        rf.stop_and_wait().await;
+    }
+    start_inner(connection_id, app, conn.forwards.clone(),
+                conn.ssh_handle.clone(), spec, None).await
+}
+
 #[tauri::command]
 pub async fn forward_stop(
     state: State<'_, AppState>,
@@ -173,9 +193,7 @@ pub async fn forward_stop(
     let conn = state.ssh.get(connection_id).await
         .ok_or(AppError::NotFound)?;
     if let Some(rf) = conn.forwards.remove(runtime_id).await {
-        if let Some(tx) = rf.stop_tx.lock().await.take() {
-            let _ = tx.send(());
-        }
+        rf.stop().await;
     }
     Ok(())
 }
@@ -260,24 +278,63 @@ pub(crate) async fn start_inner(
             let _ = app_emit.emit(&event, &s);
         });
 
-    let rf = match spec.kind {
+    let started = match spec.kind {
         ForwardKind::Local => {
             crate::ssh::forwards::local::start(
                 handle.clone(), spec.clone(), id, persistent_id, on_status.clone(),
-            ).await?
+            ).await
         }
         ForwardKind::Remote => {
             crate::ssh::forwards::remote::start(
                 handle.clone(), forwards.dispatch.clone(),
                 spec.clone(), id, persistent_id, on_status.clone(),
-            ).await?
+            ).await
         }
         ForwardKind::Dynamic => {
             crate::ssh::forwards::dynamic::start(
                 handle.clone(), spec.clone(), id, persistent_id, on_status.clone(),
-            ).await?
+            ).await
+        }
+    };
+    let rf = match started {
+        Ok(rf) => rf,
+        Err(AppError::PortConflict(msg)) => {
+            // Neutral: the bind address is owned by another ezTerm tab,
+            // another window/process, or this session already forwards it.
+            // Emit an amber Conflict status (the pane keeps Start available
+            // so the user can take it over) and return Ok — no error toast,
+            // nothing inserted into the registry.
+            let summary = RuntimeForwardSummary {
+                runtime_id: id,
+                persistent_id,
+                spec: spec.clone(),
+                status: ForwardStatus::Conflict { message: msg },
+            };
+            on_status(summary.clone());
+            return Ok(summary);
+        }
+        Err(e) => {
+            // Real failure. Emit the error carrying the id we allocated so
+            // several concurrent auto-start failures each get their own row
+            // instead of colliding on a sentinel id, then propagate so an
+            // awaiting caller (manual Start) sees it as a rejected command.
+            let summary = RuntimeForwardSummary {
+                runtime_id: id,
+                persistent_id,
+                spec: spec.clone(),
+                status: ForwardStatus::Error { message: e.to_string() },
+            };
+            on_status(summary);
+            return Err(e);
         }
     };
     forwards.insert(rf.clone()).await;
+    // Emit the initial Running status once, centrally. Callers that await
+    // this function (manual Start) get the summary as the return value AND
+    // this event; the pane upserts by runtime_id so they coalesce into one
+    // row. Callers that DON'T await it — the connect-time auto-start scan
+    // and the post-edit restart — rely on this event as their only signal,
+    // which is why the per-kind start fns stay silent and defer to here.
+    on_status(rf.summary());
     Ok(rf.summary())
 }

--- a/src-tauri/src/db/forwards.rs
+++ b/src-tauri/src/db/forwards.rs
@@ -123,7 +123,9 @@ pub async fn create(
     .bind(session_id)
     .bind(&input.name)
     .bind(&input.kind)
-    .bind(&input.bind_addr)
+    // Trim so a stray space in the bind address doesn't land in the row;
+    // bind_socket trims at use time too, so this just keeps storage clean.
+    .bind(input.bind_addr.trim())
     .bind(input.bind_port)
     .bind(&input.dest_addr)
     .bind(input.dest_port)
@@ -144,7 +146,7 @@ pub async fn update(pool: &SqlitePool, id: i64, input: &ForwardInput) -> Result<
     )
     .bind(&input.name)
     .bind(&input.kind)
-    .bind(&input.bind_addr)
+    .bind(input.bind_addr.trim())
     .bind(input.bind_port)
     .bind(&input.dest_addr)
     .bind(input.dest_port)

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -37,6 +37,14 @@ pub enum AppError {
     #[error("ssh: {0}")]
     Ssh(String),
 
+    /// A forward's bind address is already taken — by another ezTerm tab,
+    /// another ezTerm window/process, or (for remote) the same session
+    /// already forwarding that port. Not a failure the user needs to fix:
+    /// the surfacing layer renders it as a neutral "in use elsewhere"
+    /// state with Start still available, not a red error.
+    #[error("port conflict: {0}")]
+    PortConflict(String),
+
     #[error("authentication failed")]
     AuthFailed,
 
@@ -97,6 +105,7 @@ fn code_for(e: &AppError) -> &'static str {
         AppError::Io(_) => "io",
         AppError::Serde(_) => "serde",
         AppError::Ssh(_) => "ssh",
+        AppError::PortConflict(_) => "port_conflict",
         AppError::AuthFailed => "auth_failed",
         AppError::HostKeyMismatch { .. } => "host_key_mismatch",
         AppError::HostKeyUntrusted => "host_key_untrusted",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,6 +118,7 @@ async fn main() {
             commands::forwards::forward_delete,
             commands::forwards::forward_runtime_list,
             commands::forwards::forward_start,
+            commands::forwards::forward_replace,
             commands::forwards::forward_stop,
             commands::forwards::forward_stop_all,
             commands::xserver::xserver_status,

--- a/src-tauri/src/ssh/client.rs
+++ b/src-tauri/src/ssh/client.rs
@@ -511,6 +511,11 @@ async fn connect_impl(
                     continue;
                 }
             };
+            // start_inner emits its own status event (Running / Conflict /
+            // Error) with the real allocated runtime id — so a conflict from
+            // a second tab/window shows amber (not a hard error), and
+            // several failures don't collide on a sentinel id. We only log
+            // here.
             if let Err(e) = crate::commands::forwards::start_inner(
                 id,
                 app_for_scan.clone(),
@@ -522,15 +527,6 @@ async fn connect_impl(
                 tracing::warn!(
                     "auto-start forward {}:{} failed: {e}",
                     spec.bind_addr, spec.bind_port,
-                );
-                let _ = app_for_scan.emit(
-                    &format!("forwards:status:{id}"),
-                    &serde_json::json!({
-                        "runtime_id":    0,
-                        "persistent_id": f.id,
-                        "spec":          spec,
-                        "status":        { "status": "error", "message": e.to_string() },
-                    }),
                 );
             }
         }

--- a/src-tauri/src/ssh/forwards/dynamic.rs
+++ b/src-tauri/src/ssh/forwards/dynamic.rs
@@ -28,22 +28,33 @@ pub async fn start(
 ) -> Result<Arc<RuntimeForward>> {
     let bind = bind_socket(&spec.bind_addr, spec.bind_port)?;
     let listener = TcpListener::bind(bind).await.map_err(|e| {
-        AppError::Ssh(format_bind_error(&spec.bind_addr, spec.bind_port, &e))
+        let msg = format_bind_error(&spec.bind_addr, spec.bind_port, &e);
+        // AddrInUse → neutral conflict (another tab/window/process owns the
+        // port); other bind failures stay a hard Ssh error. See local.rs.
+        if e.kind() == std::io::ErrorKind::AddrInUse {
+            AppError::PortConflict(msg)
+        } else {
+            AppError::Ssh(msg)
+        }
     })?;
 
     let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+    let (done_tx, done_rx) = oneshot::channel::<()>();
     let rf = Arc::new(RuntimeForward {
         id:            runtime_id,
         persistent_id,
         spec:          spec.clone(),
         status:        std::sync::Mutex::new(ForwardStatus::Running),
         stop_tx:       Mutex::new(Some(stop_tx)),
+        done_rx:       Mutex::new(Some(done_rx)),
     });
 
     let rf_task = rf.clone();
     let on_status_task = on_status.clone();
     let inflight = Arc::new(Semaphore::new(MAX_INFLIGHT_PER_FORWARD));
     tokio::spawn(async move {
+        // See local.rs: keep a clean stop from clobbering an accept Error.
+        let mut error_exit = false;
         loop {
             tokio::select! {
                 _ = &mut stop_rx => break,
@@ -56,6 +67,7 @@ pub async fn start(
                                 message: format!("accept: {e}"),
                             });
                             on_status_task(rf_task.summary());
+                            error_exit = true;
                             break;
                         }
                     };
@@ -77,10 +89,15 @@ pub async fn start(
                 }
             }
         }
-        rf_task.set_status(ForwardStatus::Stopped);
-        on_status_task(rf_task.summary());
+        if !error_exit {
+            rf_task.set_status(ForwardStatus::Stopped);
+            on_status_task(rf_task.summary());
+        }
+        // Teardown done: listener dropped, local port free. See local.rs.
+        let _ = done_tx.send(());
     });
 
+    // Initial Running status is emitted centrally by `start_inner`.
     Ok(rf)
 }
 

--- a/src-tauri/src/ssh/forwards/local.rs
+++ b/src-tauri/src/ssh/forwards/local.rs
@@ -25,22 +25,37 @@ pub async fn start(
 ) -> Result<Arc<RuntimeForward>> {
     let bind = bind_socket(&spec.bind_addr, spec.bind_port)?;
     let listener = TcpListener::bind(bind).await.map_err(|e| {
-        AppError::Ssh(super::format_bind_error(&spec.bind_addr, spec.bind_port, &e))
+        let msg = super::format_bind_error(&spec.bind_addr, spec.bind_port, &e);
+        // AddrInUse is the multi-tab / multi-process case: someone else
+        // already owns this local port. Surface it as a neutral conflict,
+        // not a hard error. Other bind failures (permission, etc.) stay Ssh.
+        if e.kind() == std::io::ErrorKind::AddrInUse {
+            AppError::PortConflict(msg)
+        } else {
+            AppError::Ssh(msg)
+        }
     })?;
 
     let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+    let (done_tx, done_rx) = oneshot::channel::<()>();
     let rf = Arc::new(RuntimeForward {
         id:            runtime_id,
         persistent_id,
         spec:          spec.clone(),
         status:        std::sync::Mutex::new(ForwardStatus::Running),
         stop_tx:       Mutex::new(Some(stop_tx)),
+        done_rx:       Mutex::new(Some(done_rx)),
     });
 
     let rf_task = rf.clone();
     let on_status_task = on_status.clone();
     let inflight = Arc::new(Semaphore::new(MAX_INFLIGHT_PER_FORWARD));
     tokio::spawn(async move {
+        // Distinguishes a clean stop (emit Stopped) from an accept failure
+        // (already emitted Error) so the post-loop block doesn't clobber
+        // the Error with Stopped — which the pane treats as "remove the
+        // row", hiding the failure.
+        let mut error_exit = false;
         loop {
             tokio::select! {
                 _ = &mut stop_rx => break,
@@ -53,6 +68,7 @@ pub async fn start(
                                 message: format!("accept: {e}"),
                             });
                             on_status_task(rf_task.summary());
+                            error_exit = true;
                             break;
                         }
                     };
@@ -96,12 +112,19 @@ pub async fn start(
                 }
             }
         }
-        rf_task.set_status(ForwardStatus::Stopped);
-        on_status_task(rf_task.summary());
+        if !error_exit {
+            rf_task.set_status(ForwardStatus::Stopped);
+            on_status_task(rf_task.summary());
+        }
+        // Teardown done: the listener has been dropped and the local
+        // port is free. Wake anyone waiting to re-bind it (edit-in-place).
+        let _ = done_tx.send(());
     });
 
-    // Note: do NOT emit Running here — the command layer's awaited
-    // return value already carries the same summary, and emitting both
-    // makes the UI render the row twice for every Start.
+    // The initial Running status is emitted once, centrally, by
+    // `start_inner` after it registers the forward — that reaches the
+    // auto-start scan and post-edit restart too, not just callers that
+    // await this return value. Kinds stay silent on start to keep a
+    // single emit site.
     Ok(rf)
 }

--- a/src-tauri/src/ssh/forwards/mod.rs
+++ b/src-tauri/src/ssh/forwards/mod.rs
@@ -101,6 +101,12 @@ pub enum ForwardStatus {
     Running,
     Stopped,
     Error { message: String },
+    /// The bind address is already taken by another ezTerm tab, another
+    /// ezTerm window/process, or (remote) this session already forwarding
+    /// that port. Neutral, not a failure — the pane shows it amber with
+    /// Start still offered so the user can take it over if the other
+    /// holder goes away. Emitted instead of `Error` on `PortConflict`.
+    Conflict { message: String },
 }
 
 pub struct RuntimeForward {
@@ -109,6 +115,13 @@ pub struct RuntimeForward {
     pub spec:          ForwardSpec,
     pub status:        StdMutex<ForwardStatus>,
     pub stop_tx:       Mutex<Option<oneshot::Sender<()>>>,
+    // Fired by the listener task once its teardown is fully complete —
+    // local/dynamic have released their bound port, remote has dropped
+    // its dispatch entry and awaited `cancel_tcpip_forward`. Lets a
+    // caller that intends to re-bind the same address (edit-in-place)
+    // wait for the old listener to actually let go first. See
+    // `stop_and_wait`.
+    pub done_rx:       Mutex<Option<oneshot::Receiver<()>>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -131,6 +144,31 @@ impl RuntimeForward {
 
     pub fn set_status(&self, s: ForwardStatus) {
         *self.status.lock().expect("forward status poisoned") = s;
+    }
+
+    /// Signal the listener task to stop, without waiting for teardown.
+    /// The `Stopped` status event is emitted by the task before teardown
+    /// completes, so UI reflects the stop immediately. Use when nothing
+    /// downstream needs the bound address freed right away (user-driven
+    /// Stop, connection close). Idempotent.
+    pub async fn stop(&self) {
+        if let Some(tx) = self.stop_tx.lock().await.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Signal stop and await the listener task's full teardown so the
+    /// bound address is actually released before returning. Bounded so a
+    /// server that never answers `cancel_tcpip_forward` can't hang the
+    /// caller. Use before re-binding the same address (edit-in-place
+    /// restart). Idempotent — a second call returns immediately.
+    pub async fn stop_and_wait(&self) {
+        if let Some(tx) = self.stop_tx.lock().await.take() {
+            let _ = tx.send(());
+        }
+        if let Some(rx) = self.done_rx.lock().await.take() {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), rx).await;
+        }
     }
 }
 
@@ -186,13 +224,16 @@ impl Forwards {
     /// chance to exit cleanly (Remote needs the handle for
     /// `cancel_tcpip_forward`).
     pub async fn stop_all(&self) {
-        let ids: Vec<u64> = self.by_id.read().await.keys().copied().collect();
-        for id in ids {
-            if let Some(rf) = self.by_id.write().await.remove(&id) {
-                if let Some(tx) = rf.stop_tx.lock().await.take() {
-                    let _ = tx.send(());
-                }
-            }
+        // Drain the whole map under one lock acquisition. Taking ids then
+        // re-locking per id leaves a window where the still-running
+        // auto-start scan could insert a forward between iterations that
+        // we'd then never stop (its listener + bound port would leak).
+        let all: Vec<Arc<RuntimeForward>> = {
+            let mut guard = self.by_id.write().await;
+            guard.drain().map(|(_, rf)| rf).collect()
+        };
+        for rf in all {
+            rf.stop().await;
         }
     }
 }

--- a/src-tauri/src/ssh/forwards/remote.rs
+++ b/src-tauri/src/ssh/forwards/remote.rs
@@ -27,30 +27,35 @@ pub async fn start(
 ) -> Result<Arc<RuntimeForward>> {
     let key = (spec.bind_addr.clone(), spec.bind_port as u32);
 
-    // Per-connection dedupe: refuse a duplicate (bind_addr, bind_port)
-    // registration. Otherwise a server could re-deliver channels into
-    // an unrelated forward task that happens to share the key.
+    let (tx, mut rx) = mpsc::unbounded_channel::<Channel<Msg>>();
+
+    // Per-connection dedupe: check + insert under a single write lock so
+    // two concurrent starts for the same key can't both pass the check
+    // (TOCTOU). A duplicate is a neutral conflict — this session already
+    // forwards that port — not a hard error.
     {
-        let map = dispatch.read().expect("dispatch poisoned");
+        let mut map = dispatch.write().expect("dispatch poisoned");
         if map.contains_key(&key) {
-            return Err(AppError::Validation(format!(
-                "{}:{} is already bound by another forward on this session",
+            return Err(AppError::PortConflict(format!(
+                "{}:{} is already forwarded on this session",
                 spec.bind_addr, spec.bind_port,
             )));
         }
+        map.insert(key.clone(), tx);
     }
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<Channel<Msg>>();
-    dispatch.write().expect("dispatch poisoned").insert(key.clone(), tx);
+    // From here the dispatch entry is live. This guard removes it on every
+    // exit path — server reject below, normal teardown, or a task panic —
+    // so a stale key can't permanently block re-binding the address.
+    let guard = DispatchGuard { map: dispatch.clone(), key: key.clone() };
 
     // Request the forward on the server side. If the server rejects
-    // (AllowTcpForwarding=no, port-in-use on remote, etc.), back out
-    // the dispatch entry and surface the error to the command layer.
+    // (AllowTcpForwarding=no, port-in-use on remote, etc.), `guard` drops
+    // on return and backs the dispatch entry out.
     if let Err(e) = handle
         .tcpip_forward(spec.bind_addr.clone(), spec.bind_port as u32)
         .await
     {
-        dispatch.write().expect("dispatch poisoned").remove(&key);
         return Err(AppError::Ssh(format!(
             "tcpip_forward {}:{}: {e}",
             spec.bind_addr, spec.bind_port,
@@ -58,21 +63,24 @@ pub async fn start(
     }
 
     let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+    let (done_tx, done_rx) = oneshot::channel::<()>();
     let rf = Arc::new(RuntimeForward {
         id:            runtime_id,
         persistent_id,
         spec:          spec.clone(),
         status:        std::sync::Mutex::new(ForwardStatus::Running),
         stop_tx:       Mutex::new(Some(stop_tx)),
+        done_rx:       Mutex::new(Some(done_rx)),
     });
 
     let rf_task = rf.clone();
     let on_status_task = on_status.clone();
-    let dispatch_task = dispatch.clone();
     let handle_task = handle.clone();
-    let key_task = key.clone();
     let spec_task = spec.clone();
     tokio::spawn(async move {
+        // Owns the dispatch entry for the task's lifetime; dropped
+        // explicitly below (or on panic) to release the key.
+        let guard = guard;
         loop {
             tokio::select! {
                 _ = &mut stop_rx => break,
@@ -103,13 +111,36 @@ pub async fn start(
         // Drop the dispatch entry BEFORE awaiting cancel_tcpip_forward
         // so we don't keep accepting channels into a now-dropped mpsc
         // while waiting for the server's reply.
-        dispatch_task.write().expect("dispatch poisoned").remove(&key_task);
+        drop(guard);
         let _ = handle_task
             .cancel_tcpip_forward(spec_task.bind_addr.clone(), spec_task.bind_port as u32)
             .await;
         rf_task.set_status(ForwardStatus::Stopped);
         on_status_task(rf_task.summary());
+        // Teardown done: dispatch key dropped and the server-side remote
+        // bind cancelled. Only now is it safe to re-request the same
+        // (bind_addr, bind_port) — edit-in-place waits on this.
+        let _ = done_tx.send(());
     });
 
+    // Initial Running status is emitted centrally by `start_inner`.
     Ok(rf)
+}
+
+/// Removes a remote forward's dispatch entry when dropped. Covers the
+/// normal teardown path (dropped explicitly before `cancel_tcpip_forward`)
+/// and abnormal ones (early server-reject return, task panic) so a
+/// `(bind_addr, bind_port)` key can't leak and permanently block
+/// re-binding that address on this connection.
+struct DispatchGuard {
+    map: Arc<StdRwLock<HashMap<(String, u32), mpsc::UnboundedSender<Channel<Msg>>>>>,
+    key: (String, u32),
+}
+
+impl Drop for DispatchGuard {
+    fn drop(&mut self) {
+        if let Ok(mut m) = self.map.write() {
+            m.remove(&self.key);
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -33,6 +33,18 @@ export default function Page() {
     void invoke('ui_ready').catch(() => {});
   }, []);
 
+  // Suppress the webview's native context menu app-wide. Without this,
+  // right-clicking any area not covered by one of our own menus surfaces
+  // the browser default — whose "Reload" reloads the SPA and drops every
+  // open tab/connection. Our custom menus (sidebar, SFTP, terminal) are
+  // React onContextMenu handlers that still fire and render normally;
+  // this only cancels the native menu. Registered once at the app root.
+  useEffect(() => {
+    const onContextMenu = (e: MouseEvent) => e.preventDefault();
+    window.addEventListener('contextmenu', onContextMenu);
+    return () => window.removeEventListener('contextmenu', onContextMenu);
+  }, []);
+
   if (status === null)    return <main className="h-full flex items-center justify-center text-muted">Loading…</main>;
   if (status !== 'unlocked')
     return (

--- a/ui/components/forward-dialog.tsx
+++ b/ui/components/forward-dialog.tsx
@@ -119,10 +119,13 @@ export function ForwardDialog(props: Props) {
           bind_addr: v.bind_addr, bind_port: v.bind_port,
           dest_addr, dest_port,
         };
-        if (props.mode === 'ephemeral-edit') {
-          await api.forwardStop(props.connectionId, props.existing.runtime_id).catch(() => {});
-        }
-        const rf = await api.forwardStart(props.connectionId, { kind: 'ephemeral', spec });
+        // Editing a running tab-only forward: replace atomically on the
+        // backend (stop → wait for the bind to release → start) so re-using
+        // the same address can't race teardown into AddrInUse. A fresh
+        // ephemeral-create just starts.
+        const rf = props.mode === 'ephemeral-edit'
+          ? await api.forwardReplace(props.connectionId, props.existing.runtime_id, spec)
+          : await api.forwardStart(props.connectionId, { kind: 'ephemeral', spec });
         props.onSaved({ runtime: rf });
         props.onClose();
       }

--- a/ui/components/forwards-pane.tsx
+++ b/ui/components/forwards-pane.tsx
@@ -43,6 +43,7 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
   const [dialog, setDialog] = useState<
     | { kind: 'ephemeral-create' }
     | { kind: 'ephemeral-edit'; existing: RuntimeForward }
+    | { kind: 'persistent-edit'; forward: Forward }
     | null
   >(null);
 
@@ -175,6 +176,10 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
                            onClick={() => startPersistent(p.id)}>
                            <Play size={12}/>
                          </IconBtn>}
+                     <IconBtn title="Edit"
+                              onClick={() => setDialog({ kind: 'persistent-edit', forward: p })}>
+                       <Pencil size={12}/>
+                     </IconBtn>
                      <IconBtn title="Delete"
                               onClick={async () => {
                                 if (isRunning && connectionId != null) {
@@ -231,6 +236,20 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
                            const without = cur.filter((x) => x.runtime_id !== oldId);
                            return runtime ? [...without, runtime] : without;
                          });
+                         setDialog(null);
+                       }} />
+      )}
+      {dialog?.kind === 'persistent-edit' && (
+        // Editing saved config is a DB op, independent of a live tunnel.
+        // If one is running, forward_update stops & restarts it on the
+        // backend and the status events we already subscribe to reflect it.
+        <ForwardDialog mode="persistent-edit" forward={dialog.forward}
+                       onClose={() => setDialog(null)}
+                       onSaved={(r) => {
+                         const { persistent } = r;
+                         if (persistent) {
+                           setPersistent((cur) => cur.map((x) => x.id === persistent.id ? persistent : x));
+                         }
                          setDialog(null);
                        }} />
       )}

--- a/ui/components/forwards-pane.tsx
+++ b/ui/components/forwards-pane.tsx
@@ -9,6 +9,7 @@ import type { Tab } from '@/lib/tabs-store';
 import { toast } from '@/lib/toast';
 import { forwardLabel } from '@/lib/forwards';
 import { ForwardDialog } from './forward-dialog';
+import { ContextMenu, type MenuItem } from './context-menu';
 
 const KIND_TONE: Record<ForwardKind, string> = {
   local:   'text-blue-400',
@@ -16,22 +17,24 @@ const KIND_TONE: Record<ForwardKind, string> = {
   dynamic: 'text-emerald-400',
 };
 
-type RowStatus = 'idle' | 'running' | 'error';
+type RowStatus = 'idle' | 'running' | 'error' | 'conflict';
 
 function statusClasses(s: RowStatus): string {
   switch (s) {
-    case 'running': return 'bg-success';
-    case 'error':   return 'bg-danger';
-    default:        return 'bg-muted/60';
+    case 'running':  return 'bg-success';
+    case 'error':    return 'bg-danger';
+    case 'conflict': return 'bg-amber-500';
+    default:         return 'bg-muted/60';
   }
 }
 
 function rfStatus(rf: RuntimeForward | undefined): RowStatus {
   if (!rf) return 'idle';
   switch (rf.status.status) {
-    case 'running': return 'running';
-    case 'error':   return 'error';
-    default:        return 'idle';
+    case 'running':  return 'running';
+    case 'error':    return 'error';
+    case 'conflict': return 'conflict';
+    default:         return 'idle';
   }
 }
 
@@ -46,6 +49,7 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
     | { kind: 'persistent-edit'; forward: Forward }
     | null
   >(null);
+  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuItem[] } | null>(null);
 
   useEffect(() => {
     api.forwardList(sessionId).then(setPersistent).catch(() => {});
@@ -93,12 +97,11 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
     return () => { cancelled = true; unsub?.(); };
   }, [connectionId]);
 
-  // The runtime layer deliberately does NOT emit an initial "Running"
-  // status event (see ssh/forwards/local.rs) — the awaited return value
-  // of forward_start/forward_create carries that summary, and the caller
-  // is responsible for folding it into the list. Upsert by runtime_id so
-  // a started/created forward shows up (and flips to running) immediately
-  // instead of only appearing after the next status event or reconnect.
+  // start_inner emits an initial status event (Running / Conflict / Error)
+  // AND manual Start/Create return the same summary. Both carry the same
+  // runtime_id, so we upsert by it: the awaited return value shows the row
+  // instantly, and the event (the only signal for connect-time auto-start
+  // and post-edit restarts) coalesces into the same row rather than duping.
   const upsertRuntime = (rf: RuntimeForward) => setRuntime((cur) => {
     const idx = cur.findIndex((x) => x.runtime_id === rf.runtime_id);
     if (idx === -1) return [...cur, rf];
@@ -161,17 +164,33 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
           const rt = runtimeByPersistent.get(p.id);
           const isRunning = rt?.status.status === 'running';
           const tone = rfStatus(rt);
-          const lastError = rt?.status.status === 'error' ? rt.status.message : null;
+          const note = rt && (rt.status.status === 'error' || rt.status.status === 'conflict')
+            ? rt.status.message : null;
           const label = forwardLabel(p);
           return (
             <Row key={`p-${p.id}`} kind={p.kind} label={label}
-                 tone={tone} lastError={lastError}
+                 tone={tone} note={note}
+                 onContextMenu={(e) => {
+                   e.preventDefault();
+                   setMenu({ x: e.clientX, y: e.clientY, items: [
+                     { label: 'Edit', onClick: () => setDialog({ kind: 'persistent-edit', forward: p }) },
+                     isRunning
+                       ? { label: 'Stop', onClick: () => stop(rt!.runtime_id) }
+                       : { label: 'Start', disabled: connectionId == null, onClick: () => startPersistent(p.id) },
+                     { separator: true },
+                     { label: 'Delete', danger: true, onClick: async () => {
+                         await api.forwardDelete(p.id);
+                         setPersistent((cur) => cur.filter((x) => x.id !== p.id));
+                       } },
+                   ] });
+                 }}
                  actions={
                    <>
                      {isRunning
-                       ? <IconBtn title="Stop"  onClick={() => stop(rt!.runtime_id)}><Square size={12}/></IconBtn>
+                       ? <IconBtn title="Stop" tone="danger" onClick={() => stop(rt!.runtime_id)}><Square size={12}/></IconBtn>
                        : <IconBtn
                            title={connectionId == null ? 'Connect first to start' : 'Start'}
+                           tone="success"
                            disabled={connectionId == null}
                            onClick={() => startPersistent(p.id)}>
                            <Play size={12}/>
@@ -182,9 +201,8 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
                      </IconBtn>
                      <IconBtn title="Delete"
                               onClick={async () => {
-                                if (isRunning && connectionId != null) {
-                                  await api.forwardStop(connectionId, rt!.runtime_id).catch(() => {});
-                                }
+                                // forward_delete stops any running runtime for
+                                // this id server-side, so no separate stop call.
                                 await api.forwardDelete(p.id);
                                 setPersistent((cur) => cur.filter((x) => x.id !== p.id));
                               }}>
@@ -200,14 +218,22 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
                kind={rf.spec.kind}
                label={forwardLabel(rf.spec)}
                tone={rfStatus(rf)}
-               lastError={rf.status.status === 'error' ? rf.status.message : null}
+               note={rf.status.status === 'error' || rf.status.status === 'conflict'
+                 ? rf.status.message : null}
+               onContextMenu={(e) => {
+                 e.preventDefault();
+                 setMenu({ x: e.clientX, y: e.clientY, items: [
+                   { label: 'Edit', onClick: () => setDialog({ kind: 'ephemeral-edit', existing: rf }) },
+                   { label: 'Stop', onClick: () => stop(rf.runtime_id) },
+                 ] });
+               }}
                actions={
                  <>
                    <IconBtn title="Edit"
                             onClick={() => setDialog({ kind: 'ephemeral-edit', existing: rf })}>
                      <Pencil size={12}/>
                    </IconBtn>
-                   <IconBtn title="Stop" onClick={() => stop(rf.runtime_id)}>
+                   <IconBtn title="Stop" tone="danger" onClick={() => stop(rf.runtime_id)}>
                      <Square size={12}/>
                    </IconBtn>
                  </>
@@ -253,39 +279,55 @@ export function ForwardsPane({ tab, isVisible }: { tab: Tab; isVisible: boolean 
                          setDialog(null);
                        }} />
       )}
+
+      {menu && <ContextMenu {...menu} onClose={() => setMenu(null)} />}
     </div>
   );
 }
 
-function Row({ kind, label, tone, lastError, actions }: {
+function Row({ kind, label, tone, note, actions, onContextMenu }: {
   kind: ForwardKind; label: string; tone: RowStatus;
-  lastError: string | null; actions: React.ReactNode;
+  note: string | null; actions: React.ReactNode;
+  onContextMenu?: (e: React.MouseEvent) => void;
 }) {
   const KindIcon = kind === 'local' ? ArrowLeftRight : kind === 'remote' ? Server : Globe2;
+  // Conflict is neutral (amber); a real error is red.
+  const noteTone = tone === 'conflict' ? 'text-amber-500' : 'text-danger';
   return (
-    <div className="px-3 py-2 border-b border-border hover:bg-surface2">
+    <div
+      className="px-3 py-2 border-b border-border hover:bg-surface2"
+      // Right-click the row for its context menu (Edit / Start-Stop /
+      // Delete). The app-wide handler already suppresses the native menu.
+      onContextMenu={onContextMenu}
+    >
       <div className="flex items-center gap-2 text-sm min-w-0">
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusClasses(tone)}`} aria-hidden />
         <KindIcon size={12} className={`shrink-0 ${KIND_TONE[kind]}`} />
         <span className="truncate flex-1 font-mono text-xs">{label}</span>
         <span className="flex items-center gap-0.5 shrink-0">{actions}</span>
       </div>
-      {lastError && <div className="text-xs text-danger pl-6 mt-0.5 break-words">{lastError}</div>}
+      {note && <div className={`text-xs ${noteTone} pl-6 mt-0.5 break-words`}>{note}</div>}
     </div>
   );
 }
 
 function IconBtn({
-  children, title, onClick, disabled,
+  children, title, onClick, disabled, tone,
 }: {
   children: React.ReactNode; title: string; onClick: () => void; disabled?: boolean;
+  tone?: 'success' | 'danger';
 }) {
+  // Start is green, Stop is red; everything else follows the muted default.
+  const color =
+    tone === 'success' ? 'text-success hover:text-success'
+    : tone === 'danger' ? 'text-danger hover:text-danger'
+    : 'text-muted hover:text-fg';
   return (
     <button
       title={title}
       onClick={onClick}
       disabled={disabled}
-      className="p-1 rounded hover:bg-surface2 text-muted hover:text-fg disabled:opacity-40 disabled:cursor-not-allowed"
+      className={`p-1 rounded hover:bg-surface2 ${color} disabled:opacity-40 disabled:cursor-not-allowed`}
     >
       {children}
     </button>

--- a/ui/components/session-dialog.tsx
+++ b/ui/components/session-dialog.tsx
@@ -986,10 +986,10 @@ function ForwardsConfigPane({ sessionId }: { sessionId: number | null }) {
               <span className="text-[10px] uppercase text-success/80 border border-success/30 rounded px-1">auto</span>
             )}
             <div className="flex gap-0.5 shrink-0">
-              <button title="Edit"
+              <button type="button" title="Edit"
                       className="p-1 rounded hover:bg-surface2 text-muted hover:text-fg"
                       onClick={() => setEditing(r)}><Pencil size={12} /></button>
-              <button title="Delete"
+              <button type="button" title="Delete"
                       className="p-1 rounded hover:bg-surface2 text-muted hover:text-fg"
                       onClick={async () => {
                         await api.forwardDelete(r.id);

--- a/ui/lib/tauri.ts
+++ b/ui/lib/tauri.ts
@@ -6,7 +6,7 @@ import type {
   MobaImportPreview, MobaImportResult, MobaDuplicateStrategy, ParsedMobaSession,
   XServerStatus,
   Platform, DetectedShell,
-  Forward, ForwardInput, RuntimeForward, ForwardStartTarget,
+  Forward, ForwardInput, ForwardSpec, RuntimeForward, ForwardStartTarget,
   BackupSummary, BackupPreview, BackupSelection, RestoreSummary,
   SyncStatus, S3ConfigInput,
 } from './types';
@@ -182,6 +182,10 @@ export const api = {
     invoke<RuntimeForward[]>('forward_runtime_list', { connectionId }),
   forwardStart: (connectionId: number, target: ForwardStartTarget) =>
     invoke<RuntimeForward>('forward_start', { connectionId, target }),
+  // Edit-in-place for a tab-only forward: stops the old runtime, waits for
+  // its bind to release, then starts the new spec — one round-trip, no race.
+  forwardReplace: (connectionId: number, runtimeId: number, spec: ForwardSpec) =>
+    invoke<RuntimeForward>('forward_replace', { connectionId, runtimeId, spec }),
   forwardStop: (connectionId: number, runtimeId: number) =>
     invoke<void>('forward_stop', { connectionId, runtimeId }),
   forwardStopAll: (connectionId: number) =>

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -138,7 +138,11 @@ export interface ForwardInput {
 export type ForwardStatus =
   | { status: 'running' }
   | { status: 'stopped' }
-  | { status: 'error'; message: string };
+  | { status: 'error'; message: string }
+  // Bind address is owned by another ezTerm tab, another window/process,
+  // or (remote) this session already forwards it. Neutral, not a failure:
+  // shown amber with Start still available so the user can take it over.
+  | { status: 'conflict'; message: string };
 
 export interface RuntimeForward {
   runtime_id:    number;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
## Summary

Fixes port-forward reliability and editing, plus a couple of UI papercuts found along the way. Two themes: **you can now edit forwards from everywhere** and **forwards behave correctly across auto-start, edit-in-place, and multiple tabs/processes**.

## What changed

### Editing & UI (#125, #126, #127)
- **Fix:** Edit/Delete buttons in the Session dialog's *Forwards* tab were untyped, so they submitted the session `<form>` — clicking Edit "saved & closed" instead of opening the editor. Now `type="button"`. (#125)
- **Feature:** saved forwards are now editable from the **per-tab pane** (was only Session-dialog). (#126)
- **Fix:** right-clicking empty areas showed the webview's native menu whose **Reload wiped all app state**; suppressed the native context menu app-wide. (#127)
- Forward rows: **green Start / red Stop**, and a **right-click context menu** (Edit / Start-Stop / Delete) alongside the existing buttons.

### Forwards correctness (#128)
- **Reported bug** — starting an auto-started forward failed with *"already bound by another forward on this session."* Auto-started forwards registered in the backend but emitted **no `Running` event**, and the pane's initial fetch beat the slower auto-start scan → running forwards showed idle with a Start button → clicking Start re-bound an already-bound address. Now `start_inner` emits the initial `Running`/`Conflict`/`Error` status centrally.
- **Edit-in-place race** — editing a running forward is stop-then-restart on the same bind, and teardown was async. Added a done-completion signal + `stop_and_wait`; `forward_update` (persistent) and a new `forward_replace` command (tab-only) now await the old listener releasing the bind before re-binding.
- **Multi-tab / multi-process** — a 2nd tab of the same session or a 2nd ezTerm process collides on the shared port. New `PortConflict` → neutral **amber "in use elsewhere"** status (no toast), Start stays available for manual takeover — no red error.
- Hardening: accept-errors no longer overwritten by `Stopped`; each start failure emits its real runtime id (no `runtime_id: 0` sentinel collision); `stop_all` drains atomically; remote dispatch entry released via RAII guard; remote dedupe check+insert under one lock; `bind_addr` trimmed before store.

## Testing
- `cargo check` clean; **22 forwards unit tests pass** (`db::forwards` + command deserialization).
- `npm run typecheck` + `npm run lint` clean (0 errors).
- Manually verified end-to-end through a live SSH connection: local `-L` tunnel carried a full TLS session (auto-start visibility, edit-in-place, and amber multi-tab conflict all confirmed in the running app).

Version bumped 1.9.0 → **1.11.0** (across `Cargo.toml`, `tauri.conf.json`, `ui/package.json`).

Closes #125
Closes #126
Closes #127
Closes #128
