### PR TITLE
fix(site): point download links to GitHub Releases list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "ezterm"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "argon2 0.5.3",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "3"
 
 [workspace.package]
-version = "1.11.1"
+version = "1.11.2"
 edition = "2024"
 license = "GPL-3.0-only"
 repository = "https://github.com/ZerosAndOnesLLC/ezTerm"

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -2,10 +2,10 @@
 // site/src/pages/download.astro
 //
 // /download/ is a stable, advertise-able URL that bounces visitors to the
-// latest GitHub release. We use JavaScript + a tiny delay (rather than
+// GitHub Releases page. We use JavaScript + a tiny delay (rather than
 // meta-refresh) so we can fire a GA event before navigating. The page is
 // noindexed so Google doesn't try to merge it with the GitHub releases page.
-const TARGET = 'https://github.com/ZerosAndOnesLLC/ezTerm/releases/latest';
+const TARGET = 'https://github.com/ZerosAndOnesLLC/ezTerm/releases';
 const SITE = 'https://ezterm.zerosandones.us';
 const BASE = import.meta.env.BASE_URL;
 const GA_ID = 'G-19V4705C82';
@@ -18,7 +18,7 @@ const GA_ID = 'G-19V4705C82';
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="robots" content="noindex" />
     <title>Download ezTerm — Free SSH Client for Windows, Linux & macOS</title>
-    <meta name="description" content="Download the latest ezTerm release for Windows, Linux, or macOS — this page redirects to the newest build on GitHub Releases." />
+    <meta name="description" content="Download ezTerm for Windows, Linux, or macOS — this page redirects to the GitHub Releases page where you can pick your build." />
     <link rel="canonical" href={`${SITE}/download/`} />
     <link rel="icon" type="image/png" href={`${BASE}ezterm-icon.png`} />
     <!--
@@ -40,7 +40,7 @@ const GA_ID = 'G-19V4705C82';
       });
       gtag('event', 'download_click', {
         event_category: 'engagement',
-        event_label: 'github_releases_latest',
+        event_label: 'github_releases',
         transport_type: 'beacon',
       });
       // Give the beacon a moment to fire (browsers prioritize beacons even
@@ -66,6 +66,6 @@ const GA_ID = 'G-19V4705C82';
     <noscript>
       <meta http-equiv="refresh" content={`0; url=${TARGET}`} />
     </noscript>
-    <p>Redirecting to the latest release… If you aren't redirected, <a href={TARGET}>click here</a>.</p>
+    <p>Redirecting to downloads… If you aren't redirected, <a href={TARGET}>click here</a>.</p>
   </body>
 </html>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -20,7 +20,7 @@ const jsonLd = {
   operatingSystem: 'Windows, Linux, macOS',
   description: DESC,
   url: SITE,
-  downloadUrl: `${REPO}/releases/latest`,
+  downloadUrl: `${REPO}/releases`,
   license: 'https://www.gnu.org/licenses/gpl-3.0.en.html',
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   author: { '@type': 'Organization', name: 'ZerosAndOnes', url: 'https://github.com/ZerosAndOnesLLC' },
@@ -70,7 +70,7 @@ const jsonLd = {
       <li><a href={`${BASE}docs/`}>Docs</a></li>
       <li><a href={REPO}>GitHub</a></li>
     </ul>
-    <a class="nav-cta" href={`${REPO}/releases/latest`}>Download</a>
+    <a class="nav-cta" href={`${REPO}/releases`}>Download</a>
   </div>
 </nav>
 
@@ -86,7 +86,7 @@ const jsonLd = {
       MobaXterm-style sessions. Rust-native protocol stack. Encrypted vault by default. One binary on Windows, Linux, and macOS — and zero compromises.
     </p>
     <div class="cta-row">
-      <a class="btn btn-primary" href={`${REPO}/releases/latest`}>Get ezTerm →</a>
+      <a class="btn btn-primary" href={`${REPO}/releases`}>Get ezTerm →</a>
       <a class="btn btn-ghost" href={`${BASE}docs/`}><span class="pfx">$</span> read the docs</a>
       <a class="btn btn-ghost" href={REPO}><span class="pfx">$</span> source</a>
     </div>
@@ -256,7 +256,7 @@ const jsonLd = {
       <h2>Stop paying for <span class="grad">SSH.</span></h2>
       <p>Download a single tar.xz. Extract. Run. Cross-platform from day one — Windows, Linux, macOS.</p>
       <div class="cta-row">
-        <a class="btn btn-primary" href={`${REPO}/releases/latest`}>Download ezTerm</a>
+        <a class="btn btn-primary" href={`${REPO}/releases`}>Download ezTerm</a>
         <a class="btn btn-ghost" href={`${BASE}docs/getting-started/install/`}><span class="pfx">$</span> install guide</a>
       </div>
     </div>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ezTerm",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "identifier": "com.zerosandones.ezterm",
   "build": {
     "beforeDevCommand": "npm --prefix ui run dev",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ezterm-ui",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 5173",


### PR DESCRIPTION
## What

Point every download entry point on the marketing site at the full **GitHub Releases** page (`/releases`) instead of `/releases/latest`:

- Nav CTA, hero button, and footer button on `index.astro`
- The JSON-LD `SoftwareApplication.downloadUrl`
- The `/download/` redirect target (`download.astro`), plus its now-accurate copy/description and GA event label

## Why

`releases/latest` resolves to whatever GitHub marks as the latest **published, non-draft** release. When a newer version sits as a draft or pre-release, that redirect silently serves an older build. Linking straight to the Releases listing lets visitors always land on the current downloads and pick the build for their platform.

## Version

Bumped `1.11.1 → 1.11.2` (patch) across the Cargo workspace, `tauri.conf.json`, and `ui/package.json`.

`cargo check --workspace` passes.

_Note: branch was rebased onto current `main`; the earlier SEO/IndexNow work from this branch already landed via #121._